### PR TITLE
Add comprehensive endpoint modules and increase API coverage to 63%

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ console.log(manga.data.titles[0].title); // "Monster"
 const character = await jikan.characters.getCharacterByFullId(1);
 console.log(character.data.name); // "Spike Spiegel"
 
+// Get recent anime recommendations
+const animeRecs = await jikan.recommendations.getRecentAnimeRecommendations();
+console.log(animeRecs.data[0].content); // Recommendation text
+
 // Search for anime
 const animeResults = await jikan.anime.searchAnime({ 
   q: 'Naruto', 
@@ -1069,6 +1073,545 @@ async function analyzeCharacterAppearances(characterId: number) {
 // Usage
 const analysis = await analyzeCharacterAppearances(1);
 console.log('Character appeared in', analysis.stats.totalAnime, 'anime and', analysis.stats.totalManga, 'manga');
+```
+
+### Recommendations Endpoints
+
+#### Recent Recommendations
+
+##### `getRecentAnimeRecommendations(page?: number)`
+
+Get recent anime recommendations from the community.
+
+```typescript
+const recommendations = await jikan.recommendations.getRecentAnimeRecommendations();
+recommendations.data.forEach(rec => {
+  console.log(`${rec.entry[0].title} recommended with ${rec.entry[1].title}`);
+  console.log(`Recommendation: ${rec.content}`);
+  console.log(`By: ${rec.user.username} on ${rec.date}`);
+});
+
+// Get specific page
+const page2 = await jikan.recommendations.getRecentAnimeRecommendations(2);
+```
+
+##### `getRecentMangaRecommendations(page?: number)`
+
+Get recent manga recommendations from the community.
+
+```typescript
+const recommendations = await jikan.recommendations.getRecentMangaRecommendations();
+recommendations.data.forEach(rec => {
+  console.log(`${rec.entry[0].title} recommended with ${rec.entry[1].title}`);
+  console.log(`Recommendation: ${rec.content}`);
+  console.log(`By: ${rec.user.username} on ${rec.date}`);
+});
+
+// Get specific page
+const page3 = await jikan.recommendations.getRecentMangaRecommendations(3);
+```
+
+**Recommendation Structure:**
+- Each recommendation contains exactly 2 entries for comparison
+- `entry[0]` and `entry[1]` contain the recommended content with basic information
+- `content` contains the user's recommendation text
+- `user` contains information about who made the recommendation
+- `date` contains when the recommendation was created
+
+### Users Endpoints
+
+#### Basic User Information
+
+##### `getUserByUsername(username: string)`
+
+Retrieves basic user profile information.
+
+```typescript
+const user = await jikan.users.getUserByUsername('username');
+console.log({
+  username: user.data.username,
+  joined: user.data.joined,
+  lastOnline: user.data.last_online,
+  url: user.data.url
+});
+```
+
+##### `getUserFullProfile(username: string)`
+
+Retrieves complete user profile information including extended details.
+
+```typescript
+const user = await jikan.users.getUserFullProfile('username');
+console.log({
+  username: user.data.username,
+  about: user.data.about,
+  joined: user.data.joined,
+  location: user.data.location
+});
+```
+
+##### `getUserAbout(username: string)`
+
+Retrieves user's profile description/about section.
+
+```typescript
+const about = await jikan.users.getUserAbout('username');
+console.log(about.data.about);
+```
+
+#### User Statistics
+
+##### `getUserStatistics(username: string)`
+
+Get user's anime and manga viewing/reading statistics.
+
+```typescript
+const stats = await jikan.users.getUserStatistics('username');
+console.log({
+  animeCompleted: stats.data.anime.completed,
+  animeWatching: stats.data.anime.watching,
+  daysWatched: stats.data.anime.days_watched,
+  meanScore: stats.data.anime.mean_score,
+  
+  mangaCompleted: stats.data.manga.completed,
+  mangaReading: stats.data.manga.reading,
+  daysRead: stats.data.manga.days_read,
+  chaptersRead: stats.data.manga.chapters_read
+});
+```
+
+#### User Lists
+
+##### `getUserAnimeList(username: string, params?: object)`
+
+Get user's anime list with optional filtering.
+
+```typescript
+// Get all anime
+const animeList = await jikan.users.getUserAnimeList('username');
+
+// Filter by status
+const completed = await jikan.users.getUserAnimeList('username', { 
+  status: 'completed' 
+});
+
+const watching = await jikan.users.getUserAnimeList('username', { 
+  status: 'watching' 
+});
+
+// With pagination
+const page2 = await jikan.users.getUserAnimeList('username', { 
+  status: 'completed',
+  page: 2 
+});
+```
+
+**Available status filters:**
+- `watching` - Currently watching
+- `completed` - Completed
+- `on_hold` - On hold
+- `dropped` - Dropped
+- `plan_to_watch` - Plan to watch
+
+##### `getUserMangaList(username: string, params?: object)`
+
+Get user's manga list with optional filtering.
+
+```typescript
+// Get all manga
+const mangaList = await jikan.users.getUserMangaList('username');
+
+// Filter by status
+const reading = await jikan.users.getUserMangaList('username', { 
+  status: 'reading' 
+});
+
+const completed = await jikan.users.getUserMangaList('username', { 
+  status: 'completed' 
+});
+```
+
+**Available status filters:**
+- `reading` - Currently reading
+- `completed` - Completed
+- `on_hold` - On hold
+- `dropped` - Dropped
+- `plan_to_read` - Plan to read
+
+#### User Favorites
+
+##### `getUserFavorites(username: string)`
+
+Get user's favorite anime, manga, characters, and people.
+
+```typescript
+const favorites = await jikan.users.getUserFavorites('username');
+console.log({
+  favoriteAnime: favorites.data.anime,
+  favoriteManga: favorites.data.manga,
+  favoriteCharacters: favorites.data.characters,
+  favoritePeople: favorites.data.people
+});
+```
+
+#### Social Features
+
+##### `getUserFriends(username: string, page?: number)`
+
+Get user's friends list.
+
+```typescript
+const friends = await jikan.users.getUserFriends('username');
+friends.data.forEach(friend => {
+  console.log({
+    username: friend.username,
+    url: friend.url,
+    friendsSince: friend.friends_since
+  });
+});
+
+// Get specific page
+const friendsPage2 = await jikan.users.getUserFriends('username', 2);
+```
+
+##### `getUserClubs(username: string, page?: number)`
+
+Get clubs the user is a member of.
+
+```typescript
+const clubs = await jikan.users.getUserClubs('username');
+clubs.data.forEach(club => {
+  console.log({
+    name: club.name,
+    url: club.url,
+    members: club.members
+  });
+});
+```
+
+#### User Content
+
+##### `getUserReviews(username: string, page?: number)`
+
+Get reviews written by the user.
+
+```typescript
+const reviews = await jikan.users.getUserReviews('username');
+reviews.data.forEach(review => {
+  console.log({
+    anime: review.entry.title,
+    overallScore: review.scores.overall,
+    review: review.review.substring(0, 100) + '...',
+    date: review.date
+  });
+});
+```
+
+##### `getUserRecommendations(username: string, page?: number)`
+
+Get recommendations made by the user.
+
+```typescript
+const recommendations = await jikan.users.getUserRecommendations('username');
+recommendations.data.forEach(rec => {
+  console.log({
+    content: rec.content,
+    entry1: rec.entry[0].title,
+    entry2: rec.entry[1].title,
+    date: rec.date
+  });
+});
+```
+
+##### `getUserUpdates(username: string)`
+
+Get user's recent activity (anime/manga progress updates).
+
+```typescript
+const updates = await jikan.users.getUserUpdates('username');
+updates.data.forEach(update => {
+  console.log({
+    title: update.entry.title,
+    status: update.status,
+    progress: update.episodes_seen || update.chapters_read,
+    score: update.score,
+    date: update.date
+  });
+});
+```
+
+#### User Search
+
+##### `searchUsers(params?: object)`
+
+Search for users by username.
+
+```typescript
+// Basic search
+const users = await jikan.users.searchUsers({ q: 'username' });
+
+// With pagination and limit
+const searchResults = await jikan.users.searchUsers({
+  q: 'user',
+  page: 1,
+  limit: 10
+});
+
+users.data.forEach(user => {
+  console.log({
+    username: user.username,
+    joined: user.joined,
+    lastOnline: user.last_online
+  });
+});
+```
+
+**Search Parameters:**
+- `q?: string` - Search query (username)
+- `page?: number` - Page number for pagination
+- `limit?: number` - Results per page (max 25)
+
+### People Endpoints
+
+#### Basic Person Information
+
+##### `getPersonById(id: number)`
+
+Retrieves basic person information.
+
+```typescript
+const person = await jikan.people.getPersonById(1);
+console.log({
+  name: person.data.name,
+  birthday: person.data.birthday,
+  favorites: person.data.favorites
+});
+```
+
+##### `getPersonFullById(id: number)`
+
+Retrieves complete person information.
+
+```typescript
+const person = await jikan.people.getPersonFullById(1);
+console.log({
+  name: person.data.name,
+  about: person.data.about,
+  alternateNames: person.data.alternate_names
+});
+```
+
+#### Person Work & Roles
+
+##### `getPersonAnime(id: number)`
+
+Get anime work for a person.
+
+```typescript
+const animeWork = await jikan.people.getPersonAnime(1);
+animeWork.data.forEach(work => {
+  console.log(`${work.position} for ${work.anime.title}`);
+});
+```
+
+##### `getPersonManga(id: number)`
+
+Get manga work for a person.
+
+```typescript
+const mangaWork = await jikan.people.getPersonManga(1);
+mangaWork.data.forEach(work => {
+  console.log(`${work.position} for ${work.manga.title}`);
+});
+```
+
+##### `getPersonVoices(id: number)`
+
+Get voice acting roles for a person.
+
+```typescript
+const voices = await jikan.people.getPersonVoices(1);
+voices.data.forEach(voice => {
+  console.log(`${voice.character.name} in ${voice.anime.title} (${voice.role})`);
+});
+```
+
+#### Person Media
+
+##### `getPersonPictures(id: number)`
+
+Get pictures for a person.
+
+```typescript
+const pictures = await jikan.people.getPersonPictures(1);
+pictures.data.forEach(picture => {
+  console.log(picture.large_image_url);
+});
+```
+
+##### `getPersonExternal(id: number)`
+
+Get external links for a person.
+
+```typescript
+const external = await jikan.people.getPersonExternal(1);
+external.data.forEach(link => {
+  console.log(`${link.name}: ${link.url}`);
+});
+```
+
+#### Person Search
+
+##### `searchPeople(params?: object)`
+
+Search for people.
+
+```typescript
+const people = await jikan.people.searchPeople({ q: 'Hayao Miyazaki' });
+people.data.forEach(person => {
+  console.log(person.name);
+});
+
+// Advanced search
+const results = await jikan.people.searchPeople({
+  q: 'director',
+  order_by: 'favorites',
+  sort: 'desc',
+  limit: 10
+});
+```
+
+### Genres Endpoints
+
+##### `getAnimeGenres()`
+
+Get all available anime genres.
+
+```typescript
+const genres = await jikan.genres.getAnimeGenres();
+genres.data.forEach(genre => {
+  console.log(`${genre.name} (${genre.count} anime)`);
+});
+```
+
+##### `getMangaGenres()`
+
+Get all available manga genres.
+
+```typescript
+const genres = await jikan.genres.getMangaGenres();
+genres.data.forEach(genre => {
+  console.log(`${genre.name} (${genre.count} manga)`);
+});
+```
+
+### Schedules Endpoints
+
+##### `getSchedules(params?: object)`
+
+Get anime schedule information.
+
+```typescript
+// Get all scheduled anime
+const schedule = await jikan.schedules.getSchedules();
+
+// Get Monday anime only
+const mondayAnime = await jikan.schedules.getSchedules({ 
+  filter: 'monday' 
+});
+
+// Get safe-for-work anime with pagination
+const sfwSchedule = await jikan.schedules.getSchedules({
+  sfw: true,
+  page: 2,
+  limit: 10
+});
+
+schedule.data.forEach(anime => {
+  console.log(`${anime.title} - ${anime.broadcast.string}`);
+});
+```
+
+**Day-specific methods:**
+- `getMondaySchedule(page?: number)`
+- `getTuesdaySchedule(page?: number)`
+- `getWednesdaySchedule(page?: number)`
+- `getThursdaySchedule(page?: number)`
+- `getFridaySchedule(page?: number)`
+- `getSaturdaySchedule(page?: number)`
+- `getSundaySchedule(page?: number)`
+
+### Random Endpoints
+
+##### `getRandomAnime()`
+
+Get a random anime.
+
+```typescript
+const randomAnime = await jikan.random.getRandomAnime();
+console.log(`Random anime: ${randomAnime.data.titles[0].title}`);
+console.log(`Score: ${randomAnime.data.score}`);
+```
+
+##### `getRandomManga()`
+
+Get a random manga.
+
+```typescript
+const randomManga = await jikan.random.getRandomManga();
+console.log(`Random manga: ${randomManga.data.titles[0].title}`);
+console.log(`Score: ${randomManga.data.score}`);
+```
+
+##### `getRandomCharacter()`
+
+Get a random character.
+
+```typescript
+const randomCharacter = await jikan.random.getRandomCharacter();
+console.log(`Random character: ${randomCharacter.data.name}`);
+console.log(`Favorites: ${randomCharacter.data.favorites}`);
+```
+
+##### `getRandomPerson()`
+
+Get a random person.
+
+```typescript
+const randomPerson = await jikan.random.getRandomPerson();
+console.log(`Random person: ${randomPerson.data.name}`);
+console.log(`Favorites: ${randomPerson.data.favorites}`);
+```
+
+##### `getRandomUser()`
+
+Get a random user.
+
+```typescript
+const randomUser = await jikan.random.getRandomUser();
+console.log(`Random user: ${randomUser.data.username}`);
+console.log(`Joined: ${randomUser.data.joined}`);
+```
+
+### Characters Search
+
+##### `searchCharacters(params?: object)`
+
+Search for characters.
+
+```typescript
+const characters = await jikan.characters.searchCharacters({ q: 'Spike' });
+characters.data.forEach(character => {
+  console.log(character.name);
+});
+
+// Advanced search
+const results = await jikan.characters.searchCharacters({
+  q: 'main character',
+  order_by: 'favorites',
+  sort: 'desc',
+  limit: 10
+});
 ```
 
 ## Contributing

--- a/src/__tests__/characters.test.ts
+++ b/src/__tests__/characters.test.ts
@@ -419,4 +419,51 @@ describe('Characters Class', () => {
             }
         });
     });
+
+    describe('searchCharacters', () => {
+        it('should search characters without parameters', async () => {
+            const mockResponse: JikanResponse<CharacterResponse[]> = {
+                data: []
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await charactersClient.searchCharacters();
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('characters');
+            expect(result).toEqual(mockResponse);
+        });
+
+        it('should search characters with query', async () => {
+            const mockResponse: JikanResponse<CharacterResponse[]> = {
+                data: []
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await charactersClient.searchCharacters({ q: 'Spike' });
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('characters?q=Spike');
+            expect(result).toEqual(mockResponse);
+        });
+
+        it('should search characters with multiple parameters', async () => {
+            const mockResponse: JikanResponse<CharacterResponse[]> = {
+                data: []
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await charactersClient.searchCharacters({
+                q: 'main character',
+                order_by: 'favorites',
+                sort: 'desc',
+                limit: 10,
+                page: 2
+            });
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('characters?q=main+character&order_by=favorites&sort=desc&limit=10&page=2');
+            expect(result).toEqual(mockResponse);
+        });
+    });
 });

--- a/src/__tests__/genres.test.ts
+++ b/src/__tests__/genres.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @fileoverview Test suite for the Genres endpoint class
+ * Tests all methods of the Genres class to ensure proper API endpoint calls
+ * and response handling using mocked HTTP client
+ */
+
+import { Genres } from '../endpoints/genres';
+import JikanHttpClient from '../client/http-client';
+import { 
+    AnimeGenresResponse,
+    MangaGenresResponse
+} from '../types/genres';
+import JikanResponse from '../types/common';
+
+jest.mock('../client/http-client');
+
+describe('Genres Class', () => {
+    let genresClient: Genres;
+    let mockHttpClient: jest.Mocked<JikanHttpClient>;
+
+    beforeEach(() => {
+        mockHttpClient = new JikanHttpClient() as jest.Mocked<JikanHttpClient>;
+        genresClient = new Genres(mockHttpClient);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('getAnimeGenres', () => {
+        it('should fetch anime genres', async () => {
+            const mockResponse: JikanResponse<AnimeGenresResponse> = {
+                data: [
+                    {
+                        mal_id: 1,
+                        name: 'Action',
+                        url: 'https://myanimelist.net/anime/genre/1/Action',
+                        count: 4234
+                    },
+                    {
+                        mal_id: 2,
+                        name: 'Adventure',
+                        url: 'https://myanimelist.net/anime/genre/2/Adventure',
+                        count: 3021
+                    },
+                    {
+                        mal_id: 4,
+                        name: 'Comedy',
+                        url: 'https://myanimelist.net/anime/genre/4/Comedy',
+                        count: 5678
+                    }
+                ]
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await genresClient.getAnimeGenres();
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('genres/anime');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getMangaGenres', () => {
+        it('should fetch manga genres', async () => {
+            const mockResponse: JikanResponse<MangaGenresResponse> = {
+                data: [
+                    {
+                        mal_id: 1,
+                        name: 'Action',
+                        url: 'https://myanimelist.net/manga/genre/1/Action',
+                        count: 2145
+                    },
+                    {
+                        mal_id: 2,
+                        name: 'Adventure',
+                        url: 'https://myanimelist.net/manga/genre/2/Adventure',
+                        count: 1876
+                    },
+                    {
+                        mal_id: 4,
+                        name: 'Comedy',
+                        url: 'https://myanimelist.net/manga/genre/4/Comedy',
+                        count: 3456
+                    }
+                ]
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await genresClient.getMangaGenres();
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('genres/manga');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+});

--- a/src/__tests__/people.test.ts
+++ b/src/__tests__/people.test.ts
@@ -1,0 +1,311 @@
+/**
+ * @fileoverview Test suite for the People endpoint class
+ * Tests all methods of the People class to ensure proper API endpoint calls
+ * and response handling using mocked HTTP client
+ */
+
+import { People } from '../endpoints/people';
+import JikanHttpClient from '../client/http-client';
+import { 
+    PersonResponse,
+    PersonAnimeResponse,
+    PersonMangaResponse,
+    PersonVoicesResponse,
+    PersonPicturesResponse,
+    PersonExternalResponse
+} from '../types/people';
+import JikanResponse from '../types/common';
+
+jest.mock('../client/http-client');
+
+describe('People Class', () => {
+    let peopleClient: People;
+    let mockHttpClient: jest.Mocked<JikanHttpClient>;
+
+    beforeEach(() => {
+        mockHttpClient = new JikanHttpClient() as jest.Mocked<JikanHttpClient>;
+        peopleClient = new People(mockHttpClient);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('getPersonById', () => {
+        it('should fetch person by ID', async () => {
+            const mockResponse: JikanResponse<PersonResponse> = {
+                data: {
+                    mal_id: 1,
+                    url: 'https://myanimelist.net/people/1',
+                    name: 'Hayao Miyazaki',
+                    given_name: 'Hayao',
+                    family_name: 'Miyazaki',
+                    alternate_names: ['宮崎 駿'],
+                    birthday: '1941-01-05T00:00:00+00:00',
+                    favorites: 12345,
+                    about: 'Famous Japanese animator and director',
+                    images: {
+                        jpg: {
+                            image_url: 'https://example.com/person1.jpg'
+                        }
+                    }
+                }
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await peopleClient.getPersonById(1);
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('people/1');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getPersonFullById', () => {
+        it('should fetch full person information by ID', async () => {
+            const mockResponse: JikanResponse<PersonResponse> = {
+                data: {
+                    mal_id: 1,
+                    url: 'https://myanimelist.net/people/1',
+                    name: 'Hayao Miyazaki',
+                    given_name: 'Hayao',
+                    family_name: 'Miyazaki',
+                    alternate_names: ['宮崎 駿'],
+                    birthday: '1941-01-05T00:00:00+00:00',
+                    favorites: 12345,
+                    about: 'Famous Japanese animator and director',
+                    images: {
+                        jpg: {
+                            image_url: 'https://example.com/person1.jpg'
+                        }
+                    }
+                }
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await peopleClient.getPersonFullById(1);
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('people/1/full');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getPersonAnime', () => {
+        it('should fetch person anime work', async () => {
+            const mockResponse: JikanResponse<PersonAnimeResponse> = {
+                data: [
+                    {
+                        position: 'Director',
+                        anime: {
+                            mal_id: 164,
+                            url: 'https://myanimelist.net/anime/164',
+                            title: 'Spirited Away',
+                            images: {
+                                jpg: {
+                                    image_url: 'https://example.com/anime164.jpg',
+                                    small_image_url: 'https://example.com/anime164_small.jpg',
+                                    large_image_url: 'https://example.com/anime164_large.jpg'
+                                },
+                                webp: {
+                                    image_url: 'https://example.com/anime164.webp',
+                                    small_image_url: 'https://example.com/anime164_small.webp',
+                                    large_image_url: 'https://example.com/anime164_large.webp'
+                                }
+                            }
+                        }
+                    }
+                ]
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await peopleClient.getPersonAnime(1);
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('people/1/anime');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getPersonManga', () => {
+        it('should fetch person manga work', async () => {
+            const mockResponse: JikanResponse<PersonMangaResponse> = {
+                data: [
+                    {
+                        position: 'Story & Art',
+                        manga: {
+                            mal_id: 1,
+                            url: 'https://myanimelist.net/manga/1',
+                            title: 'Nausicaä of the Valley of the Wind',
+                            images: {
+                                jpg: {
+                                    image_url: 'https://example.com/manga1.jpg',
+                                    small_image_url: 'https://example.com/manga1_small.jpg',
+                                    large_image_url: 'https://example.com/manga1_large.jpg'
+                                },
+                                webp: {
+                                    image_url: 'https://example.com/manga1.webp',
+                                    small_image_url: 'https://example.com/manga1_small.webp',
+                                    large_image_url: 'https://example.com/manga1_large.webp'
+                                }
+                            }
+                        }
+                    }
+                ]
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await peopleClient.getPersonManga(1);
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('people/1/manga');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getPersonVoices', () => {
+        it('should fetch person voice acting roles', async () => {
+            const mockResponse: JikanResponse<PersonVoicesResponse> = {
+                data: [
+                    {
+                        role: 'Main',
+                        anime: {
+                            mal_id: 1,
+                            url: 'https://myanimelist.net/anime/1',
+                            title: 'Cowboy Bebop',
+                            images: {
+                                jpg: {
+                                    image_url: 'https://example.com/anime1.jpg',
+                                    small_image_url: 'https://example.com/anime1_small.jpg',
+                                    large_image_url: 'https://example.com/anime1_large.jpg'
+                                },
+                                webp: {
+                                    image_url: 'https://example.com/anime1.webp',
+                                    small_image_url: 'https://example.com/anime1_small.webp',
+                                    large_image_url: 'https://example.com/anime1_large.webp'
+                                }
+                            }
+                        },
+                        character: {
+                            mal_id: 1,
+                            url: 'https://myanimelist.net/character/1',
+                            name: 'Spike Spiegel',
+                            images: {
+                                jpg: {
+                                    image_url: 'https://example.com/character1.jpg',
+                                    small_image_url: 'https://example.com/character1_small.jpg'
+                                },
+                                webp: {
+                                    image_url: 'https://example.com/character1.webp',
+                                    small_image_url: 'https://example.com/character1_small.webp'
+                                }
+                            }
+                        }
+                    }
+                ]
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await peopleClient.getPersonVoices(1);
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('people/1/voices');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getPersonPictures', () => {
+        it('should fetch person pictures', async () => {
+            const mockResponse: JikanResponse<PersonPicturesResponse> = {
+                data: [
+                    {
+                        large_image_url: 'https://example.com/person1_large.jpg',
+                        small_image_url: 'https://example.com/person1_small.jpg'
+                    },
+                    {
+                        large_image_url: 'https://example.com/person1_2_large.jpg',
+                        small_image_url: 'https://example.com/person1_2_small.jpg'
+                    }
+                ]
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await peopleClient.getPersonPictures(1);
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('people/1/pictures');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getPersonExternal', () => {
+        it('should fetch person external links', async () => {
+            const mockResponse: JikanResponse<PersonExternalResponse> = {
+                data: [
+                    {
+                        name: 'Official Website',
+                        url: 'https://www.ghibli.jp/'
+                    },
+                    {
+                        name: 'Wikipedia',
+                        url: 'https://en.wikipedia.org/wiki/Hayao_Miyazaki'
+                    }
+                ]
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await peopleClient.getPersonExternal(1);
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('people/1/external');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('searchPeople', () => {
+        it('should search people without parameters', async () => {
+            const mockResponse: JikanResponse<PersonResponse[]> = {
+                data: []
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await peopleClient.searchPeople();
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('people');
+            expect(result).toEqual(mockResponse);
+        });
+
+        it('should search people with query', async () => {
+            const mockResponse: JikanResponse<PersonResponse[]> = {
+                data: []
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await peopleClient.searchPeople({ q: 'Miyazaki' });
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('people?q=Miyazaki');
+            expect(result).toEqual(mockResponse);
+        });
+
+        it('should search people with multiple parameters', async () => {
+            const mockResponse: JikanResponse<PersonResponse[]> = {
+                data: []
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await peopleClient.searchPeople({
+                q: 'director',
+                order_by: 'favorites',
+                sort: 'desc',
+                limit: 10,
+                page: 2
+            });
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('people?q=director&order_by=favorites&sort=desc&limit=10&page=2');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+});

--- a/src/__tests__/random.test.ts
+++ b/src/__tests__/random.test.ts
@@ -1,0 +1,271 @@
+/**
+ * @fileoverview Test suite for the Random endpoint class
+ * Tests all methods of the Random class to ensure proper API endpoint calls
+ * and response handling using mocked HTTP client
+ */
+
+import { Random } from '../endpoints/random';
+import JikanHttpClient from '../client/http-client';
+import { 
+    RandomAnimeResponse,
+    RandomMangaResponse,
+    RandomCharacterResponse,
+    RandomPersonResponse,
+    RandomUserResponse
+} from '../types/random';
+import JikanResponse from '../types/common';
+
+jest.mock('../client/http-client');
+
+describe('Random Class', () => {
+    let randomClient: Random;
+    let mockHttpClient: jest.Mocked<JikanHttpClient>;
+
+    beforeEach(() => {
+        mockHttpClient = new JikanHttpClient() as jest.Mocked<JikanHttpClient>;
+        randomClient = new Random(mockHttpClient);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('getRandomAnime', () => {
+        it('should fetch random anime', async () => {
+            const mockResponse: JikanResponse<RandomAnimeResponse> = {
+                data: {
+                    mal_id: 1,
+                    url: 'https://myanimelist.net/anime/1',
+                    images: {
+                        jpg: {
+                            image_url: 'https://example.com/anime1.jpg',
+                            small_image_url: 'https://example.com/anime1_small.jpg',
+                            large_image_url: 'https://example.com/anime1_large.jpg'
+                        },
+                        webp: {
+                            image_url: 'https://example.com/anime1.webp',
+                            small_image_url: 'https://example.com/anime1_small.webp',
+                            large_image_url: 'https://example.com/anime1_large.webp'
+                        }
+                    },
+                    trailer: {
+                        youtube_id: 'abc123',
+                        url: 'https://youtube.com/watch?v=abc123',
+                        embed_url: 'https://youtube.com/embed/abc123',
+                        images: {
+                            image_url: 'https://example.com/trailer.jpg',
+                            small_image_url: 'https://example.com/trailer_small.jpg',
+                            medium_image_url: 'https://example.com/trailer_medium.jpg',
+                            large_image_url: 'https://example.com/trailer_large.jpg',
+                            maximum_image_url: 'https://example.com/trailer_max.jpg'
+                        }
+                    },
+                    approved: true,
+                    titles: [{ type: 'Default', title: 'Cowboy Bebop' }],
+                    title: 'Cowboy Bebop',
+                    title_english: 'Cowboy Bebop',
+                    title_japanese: 'カウボーイビバップ',
+                    title_synonyms: [],
+                    type: 'TV',
+                    source: 'Original',
+                    episodes: 26,
+                    status: 'Finished Airing',
+                    airing: false,
+                    aired: {
+                        from: '1998-04-03T00:00:00+00:00',
+                        to: '1999-04-24T00:00:00+00:00',
+                        prop: {
+                            from: { day: 3, month: 4, year: 1998 },
+                            to: { day: 24, month: 4, year: 1999 }
+                        },
+                        string: 'Apr 3, 1998 to Apr 24, 1999'
+                    },
+                    duration: '24 min per ep',
+                    rating: 'R - 17+ (violence & profanity)',
+                    score: 8.78,
+                    scored_by: 750000,
+                    rank: 28,
+                    popularity: 43,
+                    members: 1500000,
+                    favorites: 65000,
+                    synopsis: 'In the year 2071...',
+                    background: 'Cowboy Bebop was created by...',
+                    season: 'spring',
+                    year: 1998,
+                    broadcast: {
+                        day: 'Saturdays',
+                        time: '01:00',
+                        timezone: 'Asia/Tokyo',
+                        string: 'Saturdays at 01:00 (JST)'
+                    },
+                    producers: [],
+                    licensors: [],
+                    studios: [],
+                    genres: [],
+                    explicit_genres: [],
+                    themes: [],
+                    demographics: []
+                }
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await randomClient.getRandomAnime();
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('random/anime');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getRandomManga', () => {
+        it('should fetch random manga', async () => {
+            const mockResponse: JikanResponse<RandomMangaResponse> = {
+                data: {
+                    mal_id: 1,
+                    url: 'https://myanimelist.net/manga/1',
+                    images: {
+                        jpg: {
+                            image_url: 'https://example.com/manga1.jpg',
+                            small_image_url: 'https://example.com/manga1_small.jpg',
+                            large_image_url: 'https://example.com/manga1_large.jpg'
+                        },
+                        webp: {
+                            image_url: 'https://example.com/manga1.webp',
+                            small_image_url: 'https://example.com/manga1_small.webp',
+                            large_image_url: 'https://example.com/manga1_large.webp'
+                        }
+                    },
+                    approved: true,
+                    titles: [{ type: 'Default', title: 'Monster' }],
+                    title: 'Monster',
+                    title_english: 'Monster',
+                    title_japanese: 'モンスター',
+                    title_synonyms: [],
+                    type: 'Manga',
+                    chapters: 162,
+                    volumes: 18,
+                    status: 'Finished',
+                    publishing: false,
+                    published: {
+                        from: '1994-12-05T00:00:00+00:00',
+                        to: '2001-12-20T00:00:00+00:00',
+                        prop: {
+                            from: { day: 5, month: 12, year: 1994 },
+                            to: { day: 20, month: 12, year: 2001 }
+                        },
+                        string: 'Dec 5, 1994 to Dec 20, 2001'
+                    },
+                    score: 9.13,
+                    scored_by: 85000,
+                    rank: 1,
+                    popularity: 44,
+                    members: 200000,
+                    favorites: 25000,
+                    synopsis: 'Dr. Kenzo Tenma...',
+                    background: 'Monster won...',
+                    authors: [],
+                    serializations: [],
+                    genres: [],
+                    explicit_genres: [],
+                    themes: [],
+                    demographics: []
+                }
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await randomClient.getRandomManga();
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('random/manga');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getRandomCharacter', () => {
+        it('should fetch random character', async () => {
+            const mockResponse: JikanResponse<RandomCharacterResponse> = {
+                data: {
+                    mal_id: 1,
+                    url: 'https://myanimelist.net/character/1',
+                    images: {
+                        jpg: {
+                            image_url: 'https://example.com/character1.jpg',
+                            small_image_url: 'https://example.com/character1_small.jpg'
+                        },
+                        webp: {
+                            image_url: 'https://example.com/character1.webp',
+                            small_image_url: 'https://example.com/character1_small.webp'
+                        }
+                    },
+                    name: 'Spike Spiegel',
+                    name_kanji: 'スパイク・スピーゲル',
+                    nicknames: ['Spike'],
+                    favorites: 15000,
+                    about: 'Spike Spiegel is a bounty hunter...'
+                }
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await randomClient.getRandomCharacter();
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('random/characters');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getRandomPerson', () => {
+        it('should fetch random person', async () => {
+            const mockResponse: JikanResponse<RandomPersonResponse> = {
+                data: {
+                    mal_id: 1,
+                    url: 'https://myanimelist.net/people/1',
+                    name: 'Hayao Miyazaki',
+                    given_name: 'Hayao',
+                    family_name: 'Miyazaki',
+                    alternate_names: ['宮崎 駿'],
+                    birthday: '1941-01-05T00:00:00+00:00',
+                    favorites: 12345,
+                    about: 'Famous Japanese animator and director',
+                    images: {
+                        jpg: {
+                            image_url: 'https://example.com/person1.jpg'
+                        }
+                    }
+                }
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await randomClient.getRandomPerson();
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('random/people');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getRandomUser', () => {
+        it('should fetch random user', async () => {
+            const mockResponse: JikanResponse<RandomUserResponse> = {
+                data: {
+                    mal_id: 1,
+                    username: 'testuser',
+                    url: 'https://myanimelist.net/profile/testuser',
+                    images: {
+                        jpg: { image_url: 'https://example.com/user1.jpg' },
+                        webp: { image_url: 'https://example.com/user1.webp' }
+                    },
+                    last_online: '2023-01-01T00:00:00+00:00',
+                    joined: '2020-01-01T00:00:00+00:00'
+                }
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await randomClient.getRandomUser();
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('random/users');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+});

--- a/src/__tests__/recommendations.test.ts
+++ b/src/__tests__/recommendations.test.ts
@@ -1,0 +1,204 @@
+/**
+ * @fileoverview Test suite for the Recommendations endpoint class
+ * Tests all methods of the Recommendations class to ensure proper API endpoint calls
+ * and response handling using mocked HTTP client
+ */
+
+import { Recommendations } from '../endpoints/recommendations';
+import JikanHttpClient from '../client/http-client';
+import { 
+    AnimeRecommendationResponse,
+    MangaRecommendationResponse,
+    RecommendationData
+} from '../types/recommendations';
+import JikanResponse from '../types/common';
+
+jest.mock('../client/http-client');
+
+describe('Recommendations Class', () => {
+    let recommendationsClient: Recommendations;
+    let mockHttpClient: jest.Mocked<JikanHttpClient>;
+
+    beforeEach(() => {
+        mockHttpClient = new JikanHttpClient() as jest.Mocked<JikanHttpClient>;
+        recommendationsClient = new Recommendations(mockHttpClient);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('getRecentAnimeRecommendations', () => {
+        it('should fetch recent anime recommendations without page parameter', async () => {
+            const mockRecommendation: RecommendationData = {
+                mal_id: '1',
+                entry: [
+                    {
+                        mal_id: 1,
+                        url: 'https://myanimelist.net/anime/1',
+                        title: 'Cowboy Bebop',
+                        images: {
+                            jpg: {
+                                image_url: 'https://example.com/1.jpg',
+                                small_image_url: 'https://example.com/1_small.jpg',
+                                large_image_url: 'https://example.com/1_large.jpg'
+                            },
+                            webp: {
+                                image_url: 'https://example.com/1.webp',
+                                small_image_url: 'https://example.com/1_small.webp',
+                                large_image_url: 'https://example.com/1_large.webp'
+                            }
+                        }
+                    },
+                    {
+                        mal_id: 2,
+                        url: 'https://myanimelist.net/anime/2',
+                        title: 'Samurai Champloo',
+                        images: {
+                            jpg: {
+                                image_url: 'https://example.com/2.jpg',
+                                small_image_url: 'https://example.com/2_small.jpg',
+                                large_image_url: 'https://example.com/2_large.jpg'
+                            },
+                            webp: {
+                                image_url: 'https://example.com/2.webp',
+                                small_image_url: 'https://example.com/2_small.webp',
+                                large_image_url: 'https://example.com/2_large.webp'
+                            }
+                        }
+                    }
+                ],
+                content: 'Both have great soundtracks and similar vibe',
+                date: '2023-01-01T00:00:00+00:00',
+                user: {
+                    username: 'testuser',
+                    url: 'https://myanimelist.net/profile/testuser'
+                }
+            };
+
+            const mockResponse: JikanResponse<AnimeRecommendationResponse> = {
+                data: [mockRecommendation]
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await recommendationsClient.getRecentAnimeRecommendations();
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('recommendations/anime');
+            expect(result).toEqual(mockResponse);
+        });
+
+        it('should fetch recent anime recommendations with page parameter', async () => {
+            const mockResponse: JikanResponse<AnimeRecommendationResponse> = {
+                data: []
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await recommendationsClient.getRecentAnimeRecommendations(2);
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('recommendations/anime?page=2');
+            expect(result).toEqual(mockResponse);
+        });
+
+        it('should fetch recent anime recommendations with page 1 (no page param in URL)', async () => {
+            const mockResponse: JikanResponse<AnimeRecommendationResponse> = {
+                data: []
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await recommendationsClient.getRecentAnimeRecommendations(1);
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('recommendations/anime');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getRecentMangaRecommendations', () => {
+        it('should fetch recent manga recommendations without page parameter', async () => {
+            const mockRecommendation: RecommendationData = {
+                mal_id: '2',
+                entry: [
+                    {
+                        mal_id: 1,
+                        url: 'https://myanimelist.net/manga/1',
+                        title: 'Monster',
+                        images: {
+                            jpg: {
+                                image_url: 'https://example.com/manga1.jpg',
+                                small_image_url: 'https://example.com/manga1_small.jpg',
+                                large_image_url: 'https://example.com/manga1_large.jpg'
+                            },
+                            webp: {
+                                image_url: 'https://example.com/manga1.webp',
+                                small_image_url: 'https://example.com/manga1_small.webp',
+                                large_image_url: 'https://example.com/manga1_large.webp'
+                            }
+                        }
+                    },
+                    {
+                        mal_id: 2,
+                        url: 'https://myanimelist.net/manga/2',
+                        title: '20th Century Boys',
+                        images: {
+                            jpg: {
+                                image_url: 'https://example.com/manga2.jpg',
+                                small_image_url: 'https://example.com/manga2_small.jpg',
+                                large_image_url: 'https://example.com/manga2_large.jpg'
+                            },
+                            webp: {
+                                image_url: 'https://example.com/manga2.webp',
+                                small_image_url: 'https://example.com/manga2_small.webp',
+                                large_image_url: 'https://example.com/manga2_large.webp'
+                            }
+                        }
+                    }
+                ],
+                content: 'Both are psychological thrillers by Naoki Urasawa',
+                date: '2023-01-01T00:00:00+00:00',
+                user: {
+                    username: 'mangafan',
+                    url: 'https://myanimelist.net/profile/mangafan'
+                }
+            };
+
+            const mockResponse: JikanResponse<MangaRecommendationResponse> = {
+                data: [mockRecommendation]
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await recommendationsClient.getRecentMangaRecommendations();
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('recommendations/manga');
+            expect(result).toEqual(mockResponse);
+        });
+
+        it('should fetch recent manga recommendations with page parameter', async () => {
+            const mockResponse: JikanResponse<MangaRecommendationResponse> = {
+                data: []
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await recommendationsClient.getRecentMangaRecommendations(3);
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('recommendations/manga?page=3');
+            expect(result).toEqual(mockResponse);
+        });
+
+        it('should fetch recent manga recommendations with page 1 (no page param in URL)', async () => {
+            const mockResponse: JikanResponse<MangaRecommendationResponse> = {
+                data: []
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await recommendationsClient.getRecentMangaRecommendations(1);
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('recommendations/manga');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+});

--- a/src/__tests__/schedules.test.ts
+++ b/src/__tests__/schedules.test.ts
@@ -1,0 +1,248 @@
+/**
+ * @fileoverview Test suite for the Schedules endpoint class
+ * Tests all methods of the Schedules class to ensure proper API endpoint calls
+ * and response handling using mocked HTTP client
+ */
+
+import { Schedules } from '../endpoints/schedules';
+import JikanHttpClient from '../client/http-client';
+import { ScheduleResponse } from '../types/schedules';
+import JikanResponse from '../types/common';
+
+jest.mock('../client/http-client');
+
+describe('Schedules Class', () => {
+    let schedulesClient: Schedules;
+    let mockHttpClient: jest.Mocked<JikanHttpClient>;
+
+    beforeEach(() => {
+        mockHttpClient = new JikanHttpClient() as jest.Mocked<JikanHttpClient>;
+        schedulesClient = new Schedules(mockHttpClient);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    const createMockScheduleEntry = () => ({
+        mal_id: 1,
+        url: 'https://myanimelist.net/anime/1',
+        title: 'Test Anime',
+        titles: [{ type: 'Default', title: 'Test Anime' }],
+        images: {
+            jpg: {
+                image_url: 'https://example.com/anime1.jpg',
+                small_image_url: 'https://example.com/anime1_small.jpg',
+                large_image_url: 'https://example.com/anime1_large.jpg'
+            },
+            webp: {
+                image_url: 'https://example.com/anime1.webp',
+                small_image_url: 'https://example.com/anime1_small.webp',
+                large_image_url: 'https://example.com/anime1_large.webp'
+            }
+        },
+        type: 'TV',
+        source: 'Manga',
+        episodes: 12,
+        status: 'Currently Airing',
+        airing: true,
+        aired: {
+            from: '2023-01-01T00:00:00+00:00',
+            to: null,
+            prop: {
+                from: { day: 1, month: 1, year: 2023 },
+                to: { day: null, month: null, year: null }
+            },
+            string: 'Jan 1, 2023 to ?'
+        },
+        duration: '24 min per ep',
+        rating: 'PG-13',
+        score: 8.5,
+        scored_by: 12345,
+        rank: 100,
+        popularity: 500,
+        members: 50000,
+        favorites: 1000,
+        synopsis: 'A test anime description',
+        background: 'Background info',
+        season: 'winter',
+        year: 2023,
+        broadcast: {
+            day: 'Mondays',
+            time: '22:30',
+            timezone: 'Asia/Tokyo',
+            string: 'Mondays at 22:30 (JST)'
+        },
+        producers: [],
+        licensors: [],
+        studios: [],
+        genres: [],
+        explicit_genres: [],
+        themes: [],
+        demographics: []
+    });
+
+    describe('getSchedules', () => {
+        it('should fetch schedules without parameters', async () => {
+            const mockResponse: JikanResponse<ScheduleResponse> = {
+                data: [createMockScheduleEntry()]
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await schedulesClient.getSchedules();
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('schedules');
+            expect(result).toEqual(mockResponse);
+        });
+
+        it('should fetch schedules with filter parameter', async () => {
+            const mockResponse: JikanResponse<ScheduleResponse> = {
+                data: [createMockScheduleEntry()]
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await schedulesClient.getSchedules({ filter: 'monday' });
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('schedules?filter=monday');
+            expect(result).toEqual(mockResponse);
+        });
+
+        it('should fetch schedules with multiple parameters', async () => {
+            const mockResponse: JikanResponse<ScheduleResponse> = {
+                data: [createMockScheduleEntry()]
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await schedulesClient.getSchedules({
+                filter: 'tuesday',
+                sfw: true,
+                page: 2,
+                limit: 10
+            });
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('schedules?filter=tuesday&sfw=true&page=2&limit=10');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getMondaySchedule', () => {
+        it('should fetch Monday schedule without pagination', async () => {
+            const mockResponse: JikanResponse<ScheduleResponse> = {
+                data: [createMockScheduleEntry()]
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await schedulesClient.getMondaySchedule();
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('schedules?filter=monday');
+            expect(result).toEqual(mockResponse);
+        });
+
+        it('should fetch Monday schedule with pagination', async () => {
+            const mockResponse: JikanResponse<ScheduleResponse> = {
+                data: [createMockScheduleEntry()]
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await schedulesClient.getMondaySchedule(2);
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('schedules?filter=monday&page=2');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getTuesdaySchedule', () => {
+        it('should fetch Tuesday schedule', async () => {
+            const mockResponse: JikanResponse<ScheduleResponse> = {
+                data: [createMockScheduleEntry()]
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await schedulesClient.getTuesdaySchedule();
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('schedules?filter=tuesday');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getWednesdaySchedule', () => {
+        it('should fetch Wednesday schedule', async () => {
+            const mockResponse: JikanResponse<ScheduleResponse> = {
+                data: [createMockScheduleEntry()]
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await schedulesClient.getWednesdaySchedule();
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('schedules?filter=wednesday');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getThursdaySchedule', () => {
+        it('should fetch Thursday schedule', async () => {
+            const mockResponse: JikanResponse<ScheduleResponse> = {
+                data: [createMockScheduleEntry()]
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await schedulesClient.getThursdaySchedule();
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('schedules?filter=thursday');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getFridaySchedule', () => {
+        it('should fetch Friday schedule', async () => {
+            const mockResponse: JikanResponse<ScheduleResponse> = {
+                data: [createMockScheduleEntry()]
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await schedulesClient.getFridaySchedule();
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('schedules?filter=friday');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getSaturdaySchedule', () => {
+        it('should fetch Saturday schedule', async () => {
+            const mockResponse: JikanResponse<ScheduleResponse> = {
+                data: [createMockScheduleEntry()]
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await schedulesClient.getSaturdaySchedule();
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('schedules?filter=saturday');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getSundaySchedule', () => {
+        it('should fetch Sunday schedule', async () => {
+            const mockResponse: JikanResponse<ScheduleResponse> = {
+                data: [createMockScheduleEntry()]
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await schedulesClient.getSundaySchedule();
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('schedules?filter=sunday');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+});

--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -1,0 +1,298 @@
+/**
+ * @fileoverview Test suite for the Users endpoint class
+ * Tests all methods of the Users class to ensure proper API endpoint calls
+ * and response handling using mocked HTTP client
+ */
+
+import { Users } from '../endpoints/users';
+import JikanHttpClient from '../client/http-client';
+import { 
+    UserResponse,
+    UserStatisticsResponse,
+    UserFavoritesResponse,
+    UserAnimeListResponse,
+    UserMangaListResponse,
+    UserFriendsResponse,
+    UserReviewResponse,
+    UserRecommendationResponse,
+    UserClubResponse,
+    UserUpdateResponse
+} from '../types/users';
+import JikanResponse from '../types/common';
+
+jest.mock('../client/http-client');
+
+describe('Users Class', () => {
+    let usersClient: Users;
+    let mockHttpClient: jest.Mocked<JikanHttpClient>;
+
+    beforeEach(() => {
+        mockHttpClient = new JikanHttpClient() as jest.Mocked<JikanHttpClient>;
+        usersClient = new Users(mockHttpClient);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('getUserByUsername', () => {
+        it('should fetch user by username', async () => {
+            const mockResponse: JikanResponse<UserResponse> = {
+                data: {
+                    mal_id: 1,
+                    username: 'testuser',
+                    url: 'https://myanimelist.net/profile/testuser',
+                    images: {
+                        jpg: { image_url: 'https://example.com/image.jpg' },
+                        webp: { image_url: 'https://example.com/image.webp' }
+                    },
+                    last_online: '2023-01-01T00:00:00+00:00',
+                    joined: '2020-01-01T00:00:00+00:00'
+                }
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await usersClient.getUserByUsername('testuser');
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('/users/testuser');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getUserFullProfile', () => {
+        it('should fetch full user profile by username', async () => {
+            const mockResponse: JikanResponse<UserResponse> = {
+                data: {
+                    mal_id: 1,
+                    username: 'testuser',
+                    url: 'https://myanimelist.net/profile/testuser',
+                    images: {
+                        jpg: { image_url: 'https://example.com/image.jpg' },
+                        webp: { image_url: 'https://example.com/image.webp' }
+                    },
+                    last_online: '2023-01-01T00:00:00+00:00',
+                    joined: '2020-01-01T00:00:00+00:00'
+                }
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await usersClient.getUserFullProfile('testuser');
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('/users/testuser/full');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getUserStatistics', () => {
+        it('should fetch user statistics', async () => {
+            const mockResponse: JikanResponse<UserStatisticsResponse> = {
+                data: {
+                    anime: {
+                        days_watched: 100.5,
+                        mean_score: 8.5,
+                        watching: 10,
+                        completed: 150,
+                        on_hold: 5,
+                        dropped: 3,
+                        plan_to_watch: 20,
+                        total_entries: 188,
+                        rewatched: 2,
+                        episodes_watched: 1500
+                    },
+                    manga: {
+                        days_read: 50.2,
+                        mean_score: 8.0,
+                        reading: 5,
+                        completed: 80,
+                        on_hold: 3,
+                        dropped: 1,
+                        plan_to_read: 15,
+                        total_entries: 104,
+                        reread: 1,
+                        chapters_read: 800,
+                        volumes_read: 100
+                    }
+                }
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await usersClient.getUserStatistics('testuser');
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('/users/testuser/statistics');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getUserAnimeList', () => {
+        it('should fetch user anime list without parameters', async () => {
+            const mockResponse: JikanResponse<UserAnimeListResponse[]> = {
+                data: []
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await usersClient.getUserAnimeList('testuser');
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('/users/testuser/animelist');
+            expect(result).toEqual(mockResponse);
+        });
+
+        it('should fetch user anime list with status filter', async () => {
+            const mockResponse: JikanResponse<UserAnimeListResponse[]> = {
+                data: []
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await usersClient.getUserAnimeList('testuser', { status: 'completed' });
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('/users/testuser/animelist?status=completed');
+            expect(result).toEqual(mockResponse);
+        });
+
+        it('should fetch user anime list with pagination', async () => {
+            const mockResponse: JikanResponse<UserAnimeListResponse[]> = {
+                data: []
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await usersClient.getUserAnimeList('testuser', { page: 2 });
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('/users/testuser/animelist?page=2');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getUserMangaList', () => {
+        it('should fetch user manga list without parameters', async () => {
+            const mockResponse: JikanResponse<UserMangaListResponse[]> = {
+                data: []
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await usersClient.getUserMangaList('testuser');
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('/users/testuser/mangalist');
+            expect(result).toEqual(mockResponse);
+        });
+
+        it('should fetch user manga list with status filter', async () => {
+            const mockResponse: JikanResponse<UserMangaListResponse[]> = {
+                data: []
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await usersClient.getUserMangaList('testuser', { status: 'reading' });
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('/users/testuser/mangalist?status=reading');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getUserFriends', () => {
+        it('should fetch user friends without pagination', async () => {
+            const mockResponse: JikanResponse<UserFriendsResponse[]> = {
+                data: []
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await usersClient.getUserFriends('testuser');
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('/users/testuser/friends');
+            expect(result).toEqual(mockResponse);
+        });
+
+        it('should fetch user friends with pagination', async () => {
+            const mockResponse: JikanResponse<UserFriendsResponse[]> = {
+                data: []
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await usersClient.getUserFriends('testuser', 2);
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('/users/testuser/friends?page=2');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('searchUsers', () => {
+        it('should search users without parameters', async () => {
+            const mockResponse: JikanResponse<UserResponse[]> = {
+                data: []
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await usersClient.searchUsers();
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('/users');
+            expect(result).toEqual(mockResponse);
+        });
+
+        it('should search users with query', async () => {
+            const mockResponse: JikanResponse<UserResponse[]> = {
+                data: []
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await usersClient.searchUsers({ q: 'testuser' });
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('/users?q=testuser');
+            expect(result).toEqual(mockResponse);
+        });
+
+        it('should search users with multiple parameters', async () => {
+            const mockResponse: JikanResponse<UserResponse[]> = {
+                data: []
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await usersClient.searchUsers({ q: 'test', page: 2, limit: 10 });
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('/users?q=test&page=2&limit=10');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getUserAbout', () => {
+        it('should fetch user about information', async () => {
+            const mockResponse: JikanResponse<{ about: string }> = {
+                data: {
+                    about: 'This is a test user profile description.'
+                }
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await usersClient.getUserAbout('testuser');
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('/users/testuser/about');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+
+    describe('getUserUpdates', () => {
+        it('should fetch user updates', async () => {
+            const mockResponse: JikanResponse<UserUpdateResponse[]> = {
+                data: []
+            };
+
+            mockHttpClient.get.mockResolvedValue(mockResponse);
+
+            const result = await usersClient.getUserUpdates('testuser');
+
+            expect(mockHttpClient.get).toHaveBeenCalledWith('/users/testuser/userupdates');
+            expect(result).toEqual(mockResponse);
+        });
+    });
+});

--- a/src/endpoints/characters.ts
+++ b/src/endpoints/characters.ts
@@ -8,7 +8,8 @@ import {
     CharacterAnimeResponse,
     CharacterMangaResponse,
     CharacterVoiceActorResponse,
-    CharacterPictureResponse
+    CharacterPictureResponse,
+    CharacterSearchParams
 } from "../types/characters";
 import JikanResponse from "../types/common";
 
@@ -133,5 +134,37 @@ export class Characters {
      */
     getCharacterPictures(id: number): Promise<JikanResponse<CharacterPictureResponse[]>> {
         return this.client.get<JikanResponse<CharacterPictureResponse[]>>(`/characters/${id}/pictures`);
+    }
+
+    /**
+     * Searches for characters
+     * @param {CharacterSearchParams} [params={}] - Search parameters
+     * @returns {Promise<JikanResponse<CharacterResponse[]>>} Promise that resolves to search results
+     * @example
+     * ```typescript
+     * const characters = await jikan.characters.searchCharacters({ q: 'Spike' });
+     * characters.data.forEach(character => {
+     *   console.log(character.name);
+     * });
+     * 
+     * // Advanced search
+     * const results = await jikan.characters.searchCharacters({
+     *   q: 'main character',
+     *   order_by: 'favorites',
+     *   sort: 'desc',
+     *   limit: 10
+     * });
+     * ```
+     */
+    async searchCharacters(params: CharacterSearchParams = {}): Promise<JikanResponse<CharacterResponse[]>> {
+        const queryParams = new URLSearchParams();
+        Object.entries(params).forEach(([key, value]) => {
+            if (value !== undefined) {
+                queryParams.append(key, value.toString());
+            }
+        });
+        
+        const url = `characters${queryParams.toString() ? `?${queryParams.toString()}` : ''}`;
+        return this.client.get<CharacterResponse[]>(url);
     }
 }

--- a/src/endpoints/genres.ts
+++ b/src/endpoints/genres.ts
@@ -1,0 +1,58 @@
+/**
+ * @fileoverview Genres endpoint class for accessing genre-related data from the Jikan API
+ */
+
+import JikanHttpClient from "../client/http-client";
+import { 
+    AnimeGenresResponse,
+    MangaGenresResponse
+} from "../types/genres";
+import JikanResponse from "../types/common";
+
+/**
+ * Genres endpoint class providing methods to access genre-related data
+ * @class Genres
+ * @example
+ * ```typescript
+ * const jikan = new Jikan();
+ * const animeGenres = await jikan.genres.getAnimeGenres();
+ * const mangaGenres = await jikan.genres.getMangaGenres();
+ * ```
+ */
+export class Genres {
+    /**
+     * Creates a new Genres endpoint instance
+     * @param {JikanHttpClient} client - HTTP client for API requests
+     */
+    constructor(private client: JikanHttpClient) {}
+
+    /**
+     * Retrieves all available anime genres
+     * @returns {Promise<JikanResponse<AnimeGenresResponse>>} Promise that resolves to anime genres
+     * @example
+     * ```typescript
+     * const genres = await jikan.genres.getAnimeGenres();
+     * genres.data.forEach(genre => {
+     *   console.log(`${genre.name} (${genre.count} anime)`);
+     * });
+     * ```
+     */
+    async getAnimeGenres(): Promise<JikanResponse<AnimeGenresResponse>> {
+        return this.client.get<AnimeGenresResponse>('genres/anime');
+    }
+
+    /**
+     * Retrieves all available manga genres
+     * @returns {Promise<JikanResponse<MangaGenresResponse>>} Promise that resolves to manga genres
+     * @example
+     * ```typescript
+     * const genres = await jikan.genres.getMangaGenres();
+     * genres.data.forEach(genre => {
+     *   console.log(`${genre.name} (${genre.count} manga)`);
+     * });
+     * ```
+     */
+    async getMangaGenres(): Promise<JikanResponse<MangaGenresResponse>> {
+        return this.client.get<MangaGenresResponse>('genres/manga');
+    }
+}

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -6,3 +6,9 @@
 export { Anime } from './anime';
 export { Manga } from './manga';
 export { Characters } from './characters';
+export { Users } from './users';
+export { Recommendations } from './recommendations';
+export { People } from './people';
+export { Genres } from './genres';
+export { Schedules } from './schedules';
+export { Random } from './random';

--- a/src/endpoints/people.ts
+++ b/src/endpoints/people.ts
@@ -1,0 +1,175 @@
+/**
+ * @fileoverview People endpoint class for accessing people-related data from the Jikan API
+ */
+
+import JikanHttpClient from "../client/http-client";
+import { 
+    PersonResponse,
+    PersonAnimeResponse,
+    PersonMangaResponse,
+    PersonVoicesResponse,
+    PersonPicturesResponse,
+    PersonExternalResponse,
+    PeopleSearchParams
+} from "../types/people";
+import JikanResponse from "../types/common";
+
+/**
+ * People endpoint class providing methods to access people-related data
+ * @class People
+ * @example
+ * ```typescript
+ * const jikan = new Jikan();
+ * const person = await jikan.people.getPersonById(1);
+ * const animeWork = await jikan.people.getPersonAnime(1);
+ * ```
+ */
+export class People {
+    /**
+     * Creates a new People endpoint instance
+     * @param {JikanHttpClient} client - HTTP client for API requests
+     */
+    constructor(private client: JikanHttpClient) {}
+
+    /**
+     * Retrieves person information by MyAnimeList ID
+     * @param {number} id - MyAnimeList ID of the person
+     * @returns {Promise<JikanResponse<PersonResponse>>} Promise that resolves to person data
+     * @example
+     * ```typescript
+     * const person = await jikan.people.getPersonById(1);
+     * console.log(person.data.name);
+     * console.log(person.data.birthday);
+     * ```
+     */
+    async getPersonById(id: number): Promise<JikanResponse<PersonResponse>> {
+        return this.client.get<PersonResponse>(`people/${id}`);
+    }
+
+    /**
+     * Retrieves complete person information by MyAnimeList ID
+     * @param {number} id - MyAnimeList ID of the person
+     * @returns {Promise<JikanResponse<PersonResponse>>} Promise that resolves to complete person data
+     * @example
+     * ```typescript
+     * const person = await jikan.people.getPersonFullById(id);
+     * console.log(person.data.about);
+     * console.log(person.data.alternate_names);
+     * ```
+     */
+    async getPersonFullById(id: number): Promise<JikanResponse<PersonResponse>> {
+        return this.client.get<PersonResponse>(`people/${id}/full`);
+    }
+
+    /**
+     * Retrieves anime work for a person
+     * @param {number} id - MyAnimeList ID of the person
+     * @returns {Promise<JikanResponse<PersonAnimeResponse>>} Promise that resolves to person's anime work
+     * @example
+     * ```typescript
+     * const animeWork = await jikan.people.getPersonAnime(1);
+     * animeWork.data.forEach(work => {
+     *   console.log(`${work.position} for ${work.anime.title}`);
+     * });
+     * ```
+     */
+    async getPersonAnime(id: number): Promise<JikanResponse<PersonAnimeResponse>> {
+        return this.client.get<PersonAnimeResponse>(`people/${id}/anime`);
+    }
+
+    /**
+     * Retrieves manga work for a person
+     * @param {number} id - MyAnimeList ID of the person
+     * @returns {Promise<JikanResponse<PersonMangaResponse>>} Promise that resolves to person's manga work
+     * @example
+     * ```typescript
+     * const mangaWork = await jikan.people.getPersonManga(1);
+     * mangaWork.data.forEach(work => {
+     *   console.log(`${work.position} for ${work.manga.title}`);
+     * });
+     * ```
+     */
+    async getPersonManga(id: number): Promise<JikanResponse<PersonMangaResponse>> {
+        return this.client.get<PersonMangaResponse>(`people/${id}/manga`);
+    }
+
+    /**
+     * Retrieves voice acting roles for a person
+     * @param {number} id - MyAnimeList ID of the person
+     * @returns {Promise<JikanResponse<PersonVoicesResponse>>} Promise that resolves to person's voice acting roles
+     * @example
+     * ```typescript
+     * const voices = await jikan.people.getPersonVoices(1);
+     * voices.data.forEach(voice => {
+     *   console.log(`${voice.character.name} in ${voice.anime.title} (${voice.role})`);
+     * });
+     * ```
+     */
+    async getPersonVoices(id: number): Promise<JikanResponse<PersonVoicesResponse>> {
+        return this.client.get<PersonVoicesResponse>(`people/${id}/voices`);
+    }
+
+    /**
+     * Retrieves pictures for a person
+     * @param {number} id - MyAnimeList ID of the person
+     * @returns {Promise<JikanResponse<PersonPicturesResponse>>} Promise that resolves to person's pictures
+     * @example
+     * ```typescript
+     * const pictures = await jikan.people.getPersonPictures(1);
+     * pictures.data.forEach(picture => {
+     *   console.log(picture.large_image_url);
+     * });
+     * ```
+     */
+    async getPersonPictures(id: number): Promise<JikanResponse<PersonPicturesResponse>> {
+        return this.client.get<PersonPicturesResponse>(`people/${id}/pictures`);
+    }
+
+    /**
+     * Retrieves external links for a person
+     * @param {number} id - MyAnimeList ID of the person
+     * @returns {Promise<JikanResponse<PersonExternalResponse>>} Promise that resolves to person's external links
+     * @example
+     * ```typescript
+     * const external = await jikan.people.getPersonExternal(1);
+     * external.data.forEach(link => {
+     *   console.log(`${link.name}: ${link.url}`);
+     * });
+     * ```
+     */
+    async getPersonExternal(id: number): Promise<JikanResponse<PersonExternalResponse>> {
+        return this.client.get<PersonExternalResponse>(`people/${id}/external`);
+    }
+
+    /**
+     * Searches for people
+     * @param {PeopleSearchParams} [params={}] - Search parameters
+     * @returns {Promise<JikanResponse<PersonResponse[]>>} Promise that resolves to search results
+     * @example
+     * ```typescript
+     * const people = await jikan.people.searchPeople({ q: 'Hayao Miyazaki' });
+     * people.data.forEach(person => {
+     *   console.log(person.name);
+     * });
+     * 
+     * // Advanced search
+     * const results = await jikan.people.searchPeople({
+     *   q: 'director',
+     *   order_by: 'favorites',
+     *   sort: 'desc',
+     *   limit: 10
+     * });
+     * ```
+     */
+    async searchPeople(params: PeopleSearchParams = {}): Promise<JikanResponse<PersonResponse[]>> {
+        const queryParams = new URLSearchParams();
+        Object.entries(params).forEach(([key, value]) => {
+            if (value !== undefined) {
+                queryParams.append(key, value.toString());
+            }
+        });
+        
+        const url = `people${queryParams.toString() ? `?${queryParams.toString()}` : ''}`;
+        return this.client.get<PersonResponse[]>(url);
+    }
+}

--- a/src/endpoints/random.ts
+++ b/src/endpoints/random.ts
@@ -1,0 +1,103 @@
+/**
+ * @fileoverview Random endpoint class for accessing random content from the Jikan API
+ */
+
+import JikanHttpClient from "../client/http-client";
+import { 
+    RandomAnimeResponse,
+    RandomMangaResponse,
+    RandomCharacterResponse,
+    RandomPersonResponse,
+    RandomUserResponse
+} from "../types/random";
+import JikanResponse from "../types/common";
+
+/**
+ * Random endpoint class providing methods to access random content
+ * @class Random
+ * @example
+ * ```typescript
+ * const jikan = new Jikan();
+ * const randomAnime = await jikan.random.getRandomAnime();
+ * const randomManga = await jikan.random.getRandomManga();
+ * ```
+ */
+export class Random {
+    /**
+     * Creates a new Random endpoint instance
+     * @param {JikanHttpClient} client - HTTP client for API requests
+     */
+    constructor(private client: JikanHttpClient) {}
+
+    /**
+     * Retrieves a random anime
+     * @returns {Promise<JikanResponse<RandomAnimeResponse>>} Promise that resolves to random anime data
+     * @example
+     * ```typescript
+     * const randomAnime = await jikan.random.getRandomAnime();
+     * console.log(`Random anime: ${randomAnime.data.titles[0].title}`);
+     * console.log(`Score: ${randomAnime.data.score}`);
+     * console.log(`Episodes: ${randomAnime.data.episodes}`);
+     * ```
+     */
+    async getRandomAnime(): Promise<JikanResponse<RandomAnimeResponse>> {
+        return this.client.get<RandomAnimeResponse>('random/anime');
+    }
+
+    /**
+     * Retrieves a random manga
+     * @returns {Promise<JikanResponse<RandomMangaResponse>>} Promise that resolves to random manga data
+     * @example
+     * ```typescript
+     * const randomManga = await jikan.random.getRandomManga();
+     * console.log(`Random manga: ${randomManga.data.titles[0].title}`);
+     * console.log(`Score: ${randomManga.data.score}`);
+     * console.log(`Chapters: ${randomManga.data.chapters}`);
+     * ```
+     */
+    async getRandomManga(): Promise<JikanResponse<RandomMangaResponse>> {
+        return this.client.get<RandomMangaResponse>('random/manga');
+    }
+
+    /**
+     * Retrieves a random character
+     * @returns {Promise<JikanResponse<RandomCharacterResponse>>} Promise that resolves to random character data
+     * @example
+     * ```typescript
+     * const randomCharacter = await jikan.random.getRandomCharacter();
+     * console.log(`Random character: ${randomCharacter.data.name}`);
+     * console.log(`Favorites: ${randomCharacter.data.favorites}`);
+     * ```
+     */
+    async getRandomCharacter(): Promise<JikanResponse<RandomCharacterResponse>> {
+        return this.client.get<RandomCharacterResponse>('random/characters');
+    }
+
+    /**
+     * Retrieves a random person
+     * @returns {Promise<JikanResponse<RandomPersonResponse>>} Promise that resolves to random person data
+     * @example
+     * ```typescript
+     * const randomPerson = await jikan.random.getRandomPerson();
+     * console.log(`Random person: ${randomPerson.data.name}`);
+     * console.log(`Favorites: ${randomPerson.data.favorites}`);
+     * ```
+     */
+    async getRandomPerson(): Promise<JikanResponse<RandomPersonResponse>> {
+        return this.client.get<RandomPersonResponse>('random/people');
+    }
+
+    /**
+     * Retrieves a random user
+     * @returns {Promise<JikanResponse<RandomUserResponse>>} Promise that resolves to random user data
+     * @example
+     * ```typescript
+     * const randomUser = await jikan.random.getRandomUser();
+     * console.log(`Random user: ${randomUser.data.username}`);
+     * console.log(`Joined: ${randomUser.data.joined}`);
+     * ```
+     */
+    async getRandomUser(): Promise<JikanResponse<RandomUserResponse>> {
+        return this.client.get<RandomUserResponse>('random/users');
+    }
+}

--- a/src/endpoints/recommendations.ts
+++ b/src/endpoints/recommendations.ts
@@ -1,0 +1,74 @@
+/**
+ * @fileoverview Recommendations endpoint class for accessing recommendation data from the Jikan API
+ */
+
+import JikanHttpClient from "../client/http-client";
+import { 
+    AnimeRecommendationResponse,
+    MangaRecommendationResponse
+} from "../types/recommendations";
+import JikanResponse from "../types/common";
+
+/**
+ * Recommendations endpoint class providing methods to access recommendation data
+ * @class Recommendations
+ * @example
+ * ```typescript
+ * const jikan = new Jikan();
+ * const animeRecs = await jikan.recommendations.getRecentAnimeRecommendations();
+ * const mangaRecs = await jikan.recommendations.getRecentMangaRecommendations();
+ * ```
+ */
+export class Recommendations {
+    /**
+     * Creates a new Recommendations endpoint instance
+     * @param {JikanHttpClient} client - HTTP client for API requests
+     */
+    constructor(private client: JikanHttpClient) {}
+
+    /**
+     * Retrieves recent anime recommendations
+     * @param {number} [page=1] - Page number for pagination
+     * @returns {Promise<JikanResponse<AnimeRecommendationResponse>>} Promise that resolves to anime recommendation data
+     * @example
+     * ```typescript
+     * const recommendations = await jikan.recommendations.getRecentAnimeRecommendations();
+     * recommendations.data.forEach(rec => {
+     *   console.log(`${rec.entry[0].title} recommended with ${rec.entry[1].title}`);
+     *   console.log(`Recommendation: ${rec.content}`);
+     * });
+     * ```
+     */
+    async getRecentAnimeRecommendations(page: number = 1): Promise<JikanResponse<AnimeRecommendationResponse>> {
+        const params = new URLSearchParams();
+        if (page > 1) {
+            params.append('page', page.toString());
+        }
+        
+        const url = `recommendations/anime${params.toString() ? `?${params.toString()}` : ''}`;
+        return this.client.get<AnimeRecommendationResponse>(url);
+    }
+
+    /**
+     * Retrieves recent manga recommendations
+     * @param {number} [page=1] - Page number for pagination
+     * @returns {Promise<JikanResponse<MangaRecommendationResponse>>} Promise that resolves to manga recommendation data
+     * @example
+     * ```typescript
+     * const recommendations = await jikan.recommendations.getRecentMangaRecommendations();
+     * recommendations.data.forEach(rec => {
+     *   console.log(`${rec.entry[0].title} recommended with ${rec.entry[1].title}`);
+     *   console.log(`By: ${rec.user.username}`);
+     * });
+     * ```
+     */
+    async getRecentMangaRecommendations(page: number = 1): Promise<JikanResponse<MangaRecommendationResponse>> {
+        const params = new URLSearchParams();
+        if (page > 1) {
+            params.append('page', page.toString());
+        }
+        
+        const url = `recommendations/manga${params.toString() ? `?${params.toString()}` : ''}`;
+        return this.client.get<MangaRecommendationResponse>(url);
+    }
+}

--- a/src/endpoints/schedules.ts
+++ b/src/endpoints/schedules.ts
@@ -1,0 +1,150 @@
+/**
+ * @fileoverview Schedules endpoint class for accessing schedule-related data from the Jikan API
+ */
+
+import JikanHttpClient from "../client/http-client";
+import { 
+    ScheduleResponse,
+    ScheduleParams
+} from "../types/schedules";
+import JikanResponse from "../types/common";
+
+/**
+ * Schedules endpoint class providing methods to access anime schedule data
+ * @class Schedules
+ * @example
+ * ```typescript
+ * const jikan = new Jikan();
+ * const schedule = await jikan.schedules.getSchedules();
+ * const mondayAnime = await jikan.schedules.getSchedules({ filter: 'monday' });
+ * ```
+ */
+export class Schedules {
+    /**
+     * Creates a new Schedules endpoint instance
+     * @param {JikanHttpClient} client - HTTP client for API requests
+     */
+    constructor(private client: JikanHttpClient) {}
+
+    /**
+     * Retrieves anime schedule information
+     * @param {ScheduleParams} [params={}] - Schedule filter parameters
+     * @returns {Promise<JikanResponse<ScheduleResponse>>} Promise that resolves to schedule data
+     * @example
+     * ```typescript
+     * // Get all scheduled anime
+     * const schedule = await jikan.schedules.getSchedules();
+     * 
+     * // Get Monday anime only
+     * const mondayAnime = await jikan.schedules.getSchedules({ 
+     *   filter: 'monday' 
+     * });
+     * 
+     * // Get safe-for-work anime with pagination
+     * const sfwSchedule = await jikan.schedules.getSchedules({
+     *   sfw: true,
+     *   page: 2,
+     *   limit: 10
+     * });
+     * 
+     * schedule.data.forEach(anime => {
+     *   console.log(`${anime.title} - ${anime.broadcast.string}`);
+     * });
+     * ```
+     */
+    async getSchedules(params: ScheduleParams = {}): Promise<JikanResponse<ScheduleResponse>> {
+        const queryParams = new URLSearchParams();
+        Object.entries(params).forEach(([key, value]) => {
+            if (value !== undefined) {
+                queryParams.append(key, value.toString());
+            }
+        });
+        
+        const url = `schedules${queryParams.toString() ? `?${queryParams.toString()}` : ''}`;
+        return this.client.get<ScheduleResponse>(url);
+    }
+
+    /**
+     * Retrieves anime scheduled for Monday
+     * @param {number} [page] - Page number for pagination
+     * @returns {Promise<JikanResponse<ScheduleResponse>>} Promise that resolves to Monday schedule
+     * @example
+     * ```typescript
+     * const mondayAnime = await jikan.schedules.getMondaySchedule();
+     * mondayAnime.data.forEach(anime => {
+     *   console.log(`${anime.title} airs on ${anime.broadcast.string}`);
+     * });
+     * ```
+     */
+    async getMondaySchedule(page?: number): Promise<JikanResponse<ScheduleResponse>> {
+        const params: ScheduleParams = { filter: 'monday' };
+        if (page) params.page = page;
+        return this.getSchedules(params);
+    }
+
+    /**
+     * Retrieves anime scheduled for Tuesday
+     * @param {number} [page] - Page number for pagination
+     * @returns {Promise<JikanResponse<ScheduleResponse>>} Promise that resolves to Tuesday schedule
+     */
+    async getTuesdaySchedule(page?: number): Promise<JikanResponse<ScheduleResponse>> {
+        const params: ScheduleParams = { filter: 'tuesday' };
+        if (page) params.page = page;
+        return this.getSchedules(params);
+    }
+
+    /**
+     * Retrieves anime scheduled for Wednesday
+     * @param {number} [page] - Page number for pagination
+     * @returns {Promise<JikanResponse<ScheduleResponse>>} Promise that resolves to Wednesday schedule
+     */
+    async getWednesdaySchedule(page?: number): Promise<JikanResponse<ScheduleResponse>> {
+        const params: ScheduleParams = { filter: 'wednesday' };
+        if (page) params.page = page;
+        return this.getSchedules(params);
+    }
+
+    /**
+     * Retrieves anime scheduled for Thursday
+     * @param {number} [page] - Page number for pagination
+     * @returns {Promise<JikanResponse<ScheduleResponse>>} Promise that resolves to Thursday schedule
+     */
+    async getThursdaySchedule(page?: number): Promise<JikanResponse<ScheduleResponse>> {
+        const params: ScheduleParams = { filter: 'thursday' };
+        if (page) params.page = page;
+        return this.getSchedules(params);
+    }
+
+    /**
+     * Retrieves anime scheduled for Friday
+     * @param {number} [page] - Page number for pagination
+     * @returns {Promise<JikanResponse<ScheduleResponse>>} Promise that resolves to Friday schedule
+     */
+    async getFridaySchedule(page?: number): Promise<JikanResponse<ScheduleResponse>> {
+        const params: ScheduleParams = { filter: 'friday' };
+        if (page) params.page = page;
+        return this.getSchedules(params);
+    }
+
+    /**
+     * Retrieves anime scheduled for Saturday
+     * @param {number} [page] - Page number for pagination
+     * @returns {Promise<JikanResponse<ScheduleResponse>>} Promise that resolves to Saturday schedule
+     */
+    async getSaturdaySchedule(page?: number): Promise<JikanResponse<ScheduleResponse>> {
+        const params: ScheduleParams = { filter: 'saturday' };
+        if (page) params.page = page;
+        return this.getSchedules(params);
+    }
+
+    /**
+     * Retrieves anime scheduled for Sunday
+     * @param {number} [page] - Page number for pagination
+     * @returns {Promise<JikanResponse<ScheduleResponse>>} Promise that resolves to Sunday schedule
+     */
+    async getSundaySchedule(page?: number): Promise<JikanResponse<ScheduleResponse>> {
+        const params: ScheduleParams = { filter: 'sunday' };
+        if (page) params.page = page;
+        return this.getSchedules(params);
+    }
+}

--- a/src/endpoints/users.ts
+++ b/src/endpoints/users.ts
@@ -1,0 +1,271 @@
+/**
+ * @fileoverview Users endpoint class for accessing user-related data from the Jikan API
+ */
+
+import JikanHttpClient from "../client/http-client";
+import { 
+    UserResponse,
+    UserStatisticsResponse,
+    UserFavoritesResponse,
+    UserAnimeListResponse,
+    UserMangaListResponse,
+    UserFriendsResponse,
+    UserReviewResponse,
+    UserRecommendationResponse,
+    UserClubResponse,
+    UserUpdateResponse
+} from "../types/users";
+import JikanResponse from "../types/common";
+
+/**
+ * Users endpoint class providing methods to access user-related data
+ * @class Users
+ * @example
+ * ```typescript
+ * const jikan = new Jikan();
+ * const user = await jikan.users.getUserByUsername('username');
+ * const stats = await jikan.users.getUserStatistics('username');
+ * ```
+ */
+export class Users {
+    /**
+     * Creates a new Users endpoint instance
+     * @param {JikanHttpClient} client - HTTP client for API requests
+     */
+    constructor(private client: JikanHttpClient) {}
+
+    /**
+     * Retrieves user profile information by username
+     * @param {string} username - Username of the user
+     * @returns {Promise<JikanResponse<UserResponse>>} Promise that resolves to user data
+     * @example
+     * ```typescript
+     * const user = await jikan.users.getUserByUsername('username');
+     * console.log(user.data.username);
+     * console.log(user.data.joined);
+     * ```
+     */
+    getUserByUsername(username: string): Promise<JikanResponse<UserResponse>> {
+        return this.client.get<JikanResponse<UserResponse>>(`/users/${username}`);
+    }
+
+    /**
+     * Retrieves complete user profile information by username
+     * @param {string} username - Username of the user
+     * @returns {Promise<JikanResponse<UserResponse>>} Promise that resolves to complete user data
+     * @example
+     * ```typescript
+     * const user = await jikan.users.getUserFullProfile(username);
+     * console.log(user.data.username);
+     * console.log(user.data.about);
+     * ```
+     */
+    getUserFullProfile(username: string): Promise<JikanResponse<UserResponse>> {
+        return this.client.get<JikanResponse<UserResponse>>(`/users/${username}/full`);
+    }
+
+    /**
+     * Retrieves user statistics (anime/manga completion stats)
+     * @param {string} username - Username of the user
+     * @returns {Promise<JikanResponse<UserStatisticsResponse>>} Promise that resolves to user statistics
+     * @example
+     * ```typescript
+     * const stats = await jikan.users.getUserStatistics('username');
+     * console.log(stats.data.anime.completed);
+     * console.log(stats.data.manga.reading);
+     * ```
+     */
+    getUserStatistics(username: string): Promise<JikanResponse<UserStatisticsResponse>> {
+        return this.client.get<JikanResponse<UserStatisticsResponse>>(`/users/${username}/statistics`);
+    }
+
+    /**
+     * Retrieves user's favorite anime, manga, characters, and people
+     * @param {string} username - Username of the user
+     * @returns {Promise<JikanResponse<UserFavoritesResponse>>} Promise that resolves to user favorites
+     * @example
+     * ```typescript
+     * const favorites = await jikan.users.getUserFavorites('username');
+     * console.log(favorites.data.anime);
+     * console.log(favorites.data.characters);
+     * ```
+     */
+    getUserFavorites(username: string): Promise<JikanResponse<UserFavoritesResponse>> {
+        return this.client.get<JikanResponse<UserFavoritesResponse>>(`/users/${username}/favorites`);
+    }
+
+    /**
+     * Retrieves user's anime list with optional filtering
+     * @param {string} username - Username of the user
+     * @param {Object} [params={}] - Optional parameters for filtering
+     * @param {string} [params.status] - Status filter (watching, completed, on_hold, dropped, plan_to_watch)
+     * @param {number} [params.page] - Page number for pagination
+     * @returns {Promise<JikanResponse<UserAnimeListResponse[]>>} Promise that resolves to user's anime list
+     * @example
+     * ```typescript
+     * const animeList = await jikan.users.getUserAnimeList('username', { status: 'completed' });
+     * const watching = await jikan.users.getUserAnimeList('username', { status: 'watching' });
+     * ```
+     */
+    getUserAnimeList(username: string, params: {
+        status?: string;
+        page?: number;
+    } = {}): Promise<JikanResponse<UserAnimeListResponse[]>> {
+        const queryParams = new URLSearchParams();
+        Object.entries(params).forEach(([key, value]) => {
+            if (value !== undefined) {
+                queryParams.append(key, value.toString());
+            }
+        });
+        const queryString = queryParams.toString();
+        return this.client.get<JikanResponse<UserAnimeListResponse[]>>(`/users/${username}/animelist${queryString ? `?${queryString}` : ''}`);
+    }
+
+    /**
+     * Retrieves user's manga list with optional filtering
+     * @param {string} username - Username of the user
+     * @param {Object} [params={}] - Optional parameters for filtering
+     * @param {string} [params.status] - Status filter (reading, completed, on_hold, dropped, plan_to_read)
+     * @param {number} [params.page] - Page number for pagination
+     * @returns {Promise<JikanResponse<UserMangaListResponse[]>>} Promise that resolves to user's manga list
+     * @example
+     * ```typescript
+     * const mangaList = await jikan.users.getUserMangaList('username', { status: 'completed' });
+     * const reading = await jikan.users.getUserMangaList('username', { status: 'reading' });
+     * ```
+     */
+    getUserMangaList(username: string, params: {
+        status?: string;
+        page?: number;
+    } = {}): Promise<JikanResponse<UserMangaListResponse[]>> {
+        const queryParams = new URLSearchParams();
+        Object.entries(params).forEach(([key, value]) => {
+            if (value !== undefined) {
+                queryParams.append(key, value.toString());
+            }
+        });
+        const queryString = queryParams.toString();
+        return this.client.get<JikanResponse<UserMangaListResponse[]>>(`/users/${username}/mangalist${queryString ? `?${queryString}` : ''}`);
+    }
+
+    /**
+     * Retrieves user's friends list
+     * @param {string} username - Username of the user
+     * @param {number} [page] - Page number for pagination
+     * @returns {Promise<JikanResponse<UserFriendsResponse[]>>} Promise that resolves to user's friends
+     * @example
+     * ```typescript
+     * const friends = await jikan.users.getUserFriends('username');
+     * console.log(friends.data[0].username);
+     * ```
+     */
+    getUserFriends(username: string, page?: number): Promise<JikanResponse<UserFriendsResponse[]>> {
+        const params = page ? `?page=${page}` : '';
+        return this.client.get<JikanResponse<UserFriendsResponse[]>>(`/users/${username}/friends${params}`);
+    }
+
+    /**
+     * Retrieves reviews written by the user
+     * @param {string} username - Username of the user
+     * @param {number} [page] - Page number for pagination
+     * @returns {Promise<JikanResponse<UserReviewResponse[]>>} Promise that resolves to user's reviews
+     * @example
+     * ```typescript
+     * const reviews = await jikan.users.getUserReviews('username');
+     * console.log(reviews.data[0].review);
+     * ```
+     */
+    getUserReviews(username: string, page?: number): Promise<JikanResponse<UserReviewResponse[]>> {
+        const params = page ? `?page=${page}` : '';
+        return this.client.get<JikanResponse<UserReviewResponse[]>>(`/users/${username}/reviews${params}`);
+    }
+
+    /**
+     * Retrieves recommendations made by the user
+     * @param {string} username - Username of the user
+     * @param {number} [page] - Page number for pagination
+     * @returns {Promise<JikanResponse<UserRecommendationResponse[]>>} Promise that resolves to user's recommendations
+     * @example
+     * ```typescript
+     * const recommendations = await jikan.users.getUserRecommendations('username');
+     * console.log(recommendations.data[0].content);
+     * ```
+     */
+    getUserRecommendations(username: string, page?: number): Promise<JikanResponse<UserRecommendationResponse[]>> {
+        const params = page ? `?page=${page}` : '';
+        return this.client.get<JikanResponse<UserRecommendationResponse[]>>(`/users/${username}/recommendations${params}`);
+    }
+
+    /**
+     * Retrieves clubs the user is a member of
+     * @param {string} username - Username of the user
+     * @param {number} [page] - Page number for pagination
+     * @returns {Promise<JikanResponse<UserClubResponse[]>>} Promise that resolves to user's clubs
+     * @example
+     * ```typescript
+     * const clubs = await jikan.users.getUserClubs('username');
+     * console.log(clubs.data[0].name);
+     * ```
+     */
+    getUserClubs(username: string, page?: number): Promise<JikanResponse<UserClubResponse[]>> {
+        const params = page ? `?page=${page}` : '';
+        return this.client.get<JikanResponse<UserClubResponse[]>>(`/users/${username}/clubs${params}`);
+    }
+
+    /**
+     * Retrieves user's recent updates (anime/manga progress updates)
+     * @param {string} username - Username of the user
+     * @returns {Promise<JikanResponse<UserUpdateResponse[]>>} Promise that resolves to user's updates
+     * @example
+     * ```typescript
+     * const updates = await jikan.users.getUserUpdates('username');
+     * console.log(updates.data[0].entry.title);
+     * console.log(updates.data[0].status);
+     * ```
+     */
+    getUserUpdates(username: string): Promise<JikanResponse<UserUpdateResponse[]>> {
+        return this.client.get<JikanResponse<UserUpdateResponse[]>>(`/users/${username}/userupdates`);
+    }
+
+    /**
+     * Retrieves user's about information (profile description)
+     * @param {string} username - Username of the user
+     * @returns {Promise<JikanResponse<{ about: string }>>} Promise that resolves to user's about info
+     * @example
+     * ```typescript
+     * const about = await jikan.users.getUserAbout('username');
+     * console.log(about.data.about);
+     * ```
+     */
+    getUserAbout(username: string): Promise<JikanResponse<{ about: string }>> {
+        return this.client.get<JikanResponse<{ about: string }>>(`/users/${username}/about`);
+    }
+
+    /**
+     * Searches for users by username
+     * @param {Object} [params={}] - Search parameters
+     * @param {string} [params.q] - Search query (username)
+     * @param {number} [params.page] - Page number for pagination
+     * @param {number} [params.limit] - Results per page (max 25)
+     * @returns {Promise<JikanResponse<UserResponse[]>>} Promise that resolves to search results
+     * @example
+     * ```typescript
+     * const users = await jikan.users.searchUsers({ q: 'username' });
+     * console.log(users.data[0].username);
+     * ```
+     */
+    searchUsers(params: {
+        q?: string;
+        page?: number;
+        limit?: number;
+    } = {}): Promise<JikanResponse<UserResponse[]>> {
+        const queryParams = new URLSearchParams();
+        Object.entries(params).forEach(([key, value]) => {
+            if (value !== undefined) {
+                queryParams.append(key, value.toString());
+            }
+        });
+        const queryString = queryParams.toString();
+        return this.client.get<JikanResponse<UserResponse[]>>(`/users${queryString ? `?${queryString}` : ''}`);
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import Jikan from "./jikan";
 export * from "./types/anime";
 export * from "./types/manga";
 export * from "./types/characters";
+export * from "./types/users";
 export * from "./types/common";
 
 // Export the main Jikan class as the default export

--- a/src/jikan.ts
+++ b/src/jikan.ts
@@ -6,6 +6,12 @@ import JikanHttpClient from "./client/http-client";
 import { Anime } from "./endpoints/anime";
 import { Manga } from "./endpoints/manga";
 import { Characters } from "./endpoints/characters";
+import { Users } from "./endpoints/users";
+import { Recommendations } from "./endpoints/recommendations";
+import { People } from "./endpoints/people";
+import { Genres } from "./endpoints/genres";
+import { Schedules } from "./endpoints/schedules";
+import { Random } from "./endpoints/random";
 
 /**
  * Main Jikan API client class that provides access to various endpoints
@@ -18,6 +24,12 @@ import { Characters } from "./endpoints/characters";
  * const anime = await jikan.anime.getAnimeByFullId(1);
  * const manga = await jikan.manga.getMangaByFullId(1);
  * const character = await jikan.characters.getCharacterByFullId(1);
+ * const user = await jikan.users.getUserByUsername('username');
+ * const recommendations = await jikan.recommendations.getRecentAnimeRecommendations();
+ * const person = await jikan.people.getPersonById(1);
+ * const genres = await jikan.genres.getAnimeGenres();
+ * const schedule = await jikan.schedules.getSchedules();
+ * const randomAnime = await jikan.random.getRandomAnime();
  * ```
  */
 class Jikan {
@@ -52,6 +64,42 @@ class Jikan {
     characters: Characters;
     
     /**
+     * Users endpoint accessor
+     * @public
+     */
+    users: Users;
+    
+    /**
+     * Recommendations endpoint accessor
+     * @public
+     */
+    recommendations: Recommendations;
+    
+    /**
+     * People endpoint accessor
+     * @public
+     */
+    people: People;
+    
+    /**
+     * Genres endpoint accessor
+     * @public
+     */
+    genres: Genres;
+    
+    /**
+     * Schedules endpoint accessor
+     * @public
+     */
+    schedules: Schedules;
+    
+    /**
+     * Random endpoint accessor
+     * @public
+     */
+    random: Random;
+    
+    /**
      * Creates a new Jikan API client instance
      * @param {string} [baseUrl] - Custom base URL for the API (optional)
      * @example
@@ -71,6 +119,12 @@ class Jikan {
         this.anime = new Anime(this.client);
         this.manga = new Manga(this.client);
         this.characters = new Characters(this.client);
+        this.users = new Users(this.client);
+        this.recommendations = new Recommendations(this.client);
+        this.people = new People(this.client);
+        this.genres = new Genres(this.client);
+        this.schedules = new Schedules(this.client);
+        this.random = new Random(this.client);
     }
 }
 

--- a/src/types/characters.ts
+++ b/src/types/characters.ts
@@ -155,6 +155,23 @@ interface CharacterPictureResponse {
     small_image_url: string;
 }
 
+/**
+ * Search parameters for characters
+ * @interface CharacterSearchParams
+ */
+export interface CharacterSearchParams {
+    /** Search query */
+    q?: string;
+    /** Page number */
+    page?: number;
+    /** Results per page */
+    limit?: number;
+    /** Order by field */
+    order_by?: string;
+    /** Sort direction */
+    sort?: string;
+}
+
 export type { 
     CharacterResponse,
     CharacterAnimeResponse,

--- a/src/types/genres.ts
+++ b/src/types/genres.ts
@@ -1,0 +1,30 @@
+/**
+ * @fileoverview Type definitions for genre-related API responses
+ */
+
+/**
+ * Genre information
+ * @interface GenreResponse
+ */
+export interface GenreResponse {
+    /** MyAnimeList ID */
+    mal_id: number;
+    /** Genre name */
+    name: string;
+    /** URL to the genre page */
+    url: string;
+    /** Number of entries with this genre */
+    count: number;
+}
+
+/**
+ * Response type for anime genres
+ * @type AnimeGenresResponse
+ */
+export type AnimeGenresResponse = GenreResponse[];
+
+/**
+ * Response type for manga genres
+ * @type MangaGenresResponse
+ */
+export type MangaGenresResponse = GenreResponse[];

--- a/src/types/people.ts
+++ b/src/types/people.ts
@@ -1,0 +1,221 @@
+/**
+ * @fileoverview Type definitions for people-related API responses
+ */
+
+/**
+ * Basic person entry information
+ * @interface PersonEntry
+ */
+export interface PersonEntry {
+    /** MyAnimeList ID */
+    mal_id: number;
+    /** URL to the person's page on MyAnimeList */
+    url: string;
+    /** Person's name */
+    name: string;
+    /** Images for the person */
+    images: {
+        jpg: {
+            image_url: string;
+        };
+    };
+}
+
+/**
+ * Complete person information
+ * @interface PersonResponse
+ */
+export interface PersonResponse {
+    /** MyAnimeList ID */
+    mal_id: number;
+    /** URL to the person's page on MyAnimeList */
+    url: string;
+    /** Website URL if available */
+    website_url?: string;
+    /** Person's name */
+    name: string;
+    /** Given name */
+    given_name?: string;
+    /** Family name */
+    family_name?: string;
+    /** Alternative names */
+    alternate_names: string[];
+    /** Birthday date */
+    birthday?: string;
+    /** Number of favorites */
+    favorites: number;
+    /** Biography/about information */
+    about?: string;
+    /** Images for the person */
+    images: {
+        jpg: {
+            image_url: string;
+        };
+    };
+}
+
+/**
+ * Person's anime work entry
+ * @interface PersonAnimeWork
+ */
+export interface PersonAnimeWork {
+    /** Position/role in the anime */
+    position: string;
+    /** Anime information */
+    anime: {
+        mal_id: number;
+        url: string;
+        title: string;
+        images: {
+            jpg: {
+                image_url: string;
+                small_image_url: string;
+                large_image_url: string;
+            };
+            webp: {
+                image_url: string;
+                small_image_url: string;
+                large_image_url: string;
+            };
+        };
+    };
+}
+
+/**
+ * Person's manga work entry
+ * @interface PersonMangaWork
+ */
+export interface PersonMangaWork {
+    /** Position/role in the manga */
+    position: string;
+    /** Manga information */
+    manga: {
+        mal_id: number;
+        url: string;
+        title: string;
+        images: {
+            jpg: {
+                image_url: string;
+                small_image_url: string;
+                large_image_url: string;
+            };
+            webp: {
+                image_url: string;
+                small_image_url: string;
+                large_image_url: string;
+            };
+        };
+    };
+}
+
+/**
+ * Person's voice acting role
+ * @interface PersonVoiceRole
+ */
+export interface PersonVoiceRole {
+    /** Role type (Main, Supporting, etc.) */
+    role: string;
+    /** Anime information */
+    anime: {
+        mal_id: number;
+        url: string;
+        title: string;
+        images: {
+            jpg: {
+                image_url: string;
+                small_image_url: string;
+                large_image_url: string;
+            };
+            webp: {
+                image_url: string;
+                small_image_url: string;
+                large_image_url: string;
+            };
+        };
+    };
+    /** Character information */
+    character: {
+        mal_id: number;
+        url: string;
+        name: string;
+        images: {
+            jpg: {
+                image_url: string;
+                small_image_url: string;
+            };
+            webp: {
+                image_url: string;
+                small_image_url: string;
+            };
+        };
+    };
+}
+
+/**
+ * Person's picture
+ * @interface PersonPicture
+ */
+export interface PersonPicture {
+    /** Large image URL */
+    large_image_url: string;
+    /** Small image URL */
+    small_image_url: string;
+}
+
+/**
+ * External link for person
+ * @interface PersonExternalLink
+ */
+export interface PersonExternalLink {
+    /** Link name */
+    name: string;
+    /** Link URL */
+    url: string;
+}
+
+/**
+ * Search parameters for people
+ * @interface PeopleSearchParams
+ */
+export interface PeopleSearchParams {
+    /** Search query */
+    q?: string;
+    /** Page number */
+    page?: number;
+    /** Results per page */
+    limit?: number;
+    /** Order by field */
+    order_by?: string;
+    /** Sort direction */
+    sort?: string;
+}
+
+/**
+ * Response type for person anime work
+ * @type PersonAnimeResponse
+ */
+export type PersonAnimeResponse = PersonAnimeWork[];
+
+/**
+ * Response type for person manga work
+ * @type PersonMangaResponse
+ */
+export type PersonMangaResponse = PersonMangaWork[];
+
+/**
+ * Response type for person voice acting
+ * @type PersonVoicesResponse
+ */
+export type PersonVoicesResponse = PersonVoiceRole[];
+
+/**
+ * Response type for person pictures
+ * @type PersonPicturesResponse
+ */
+export type PersonPicturesResponse = PersonPicture[];
+
+/**
+ * Response type for person external links
+ * @type PersonExternalResponse
+ */
+export type PersonExternalResponse = PersonExternalLink[];

--- a/src/types/random.ts
+++ b/src/types/random.ts
@@ -1,0 +1,39 @@
+/**
+ * @fileoverview Type definitions for random-related API responses
+ */
+
+import { AnimeResponse } from './anime';
+import { MangaResponse } from './manga';
+import { CharacterResponse } from './characters';
+import { PersonResponse } from './people';
+import { UserResponse } from './users';
+
+/**
+ * Response type for random anime
+ * @type RandomAnimeResponse
+ */
+export type RandomAnimeResponse = AnimeResponse;
+
+/**
+ * Response type for random manga
+ * @type RandomMangaResponse
+ */
+export type RandomMangaResponse = MangaResponse;
+
+/**
+ * Response type for random character
+ * @type RandomCharacterResponse
+ */
+export type RandomCharacterResponse = CharacterResponse;
+
+/**
+ * Response type for random person
+ * @type RandomPersonResponse
+ */
+export type RandomPersonResponse = PersonResponse;
+
+/**
+ * Response type for random user
+ * @type RandomUserResponse
+ */
+export type RandomUserResponse = UserResponse;

--- a/src/types/recommendations.ts
+++ b/src/types/recommendations.ts
@@ -1,0 +1,69 @@
+/**
+ * @fileoverview Type definitions for recommendation-related API responses
+ */
+
+/**
+ * Recommendation entry containing basic information about recommended content
+ * @interface RecommendationEntry
+ */
+export interface RecommendationEntry {
+    /** MyAnimeList ID */
+    mal_id: number;
+    /** URL to the content on MyAnimeList */
+    url: string;
+    /** Title of the recommended content */
+    title: string;
+    /** Images for the recommended content */
+    images: {
+        jpg: {
+            image_url: string;
+            small_image_url: string;
+            large_image_url: string;
+        };
+        webp: {
+            image_url: string;
+            small_image_url: string;
+            large_image_url: string;
+        };
+    };
+}
+
+/**
+ * User information for recommendation
+ * @interface RecommendationUser
+ */
+export interface RecommendationUser {
+    /** Username of the user who made the recommendation */
+    username: string;
+    /** URL to the user's profile */
+    url: string;
+}
+
+/**
+ * Single recommendation data structure
+ * @interface RecommendationData
+ */
+export interface RecommendationData {
+    /** MyAnimeList ID of the recommendation */
+    mal_id: string;
+    /** Recommended content entries (always contains 2 items for comparison) */
+    entry: RecommendationEntry[];
+    /** Recommendation text content */
+    content: string;
+    /** Date when the recommendation was created */
+    date: string;
+    /** User who made the recommendation */
+    user: RecommendationUser;
+}
+
+/**
+ * Response type for anime recommendations
+ * @type AnimeRecommendationResponse
+ */
+export type AnimeRecommendationResponse = RecommendationData[];
+
+/**
+ * Response type for manga recommendations  
+ * @type MangaRecommendationResponse
+ */
+export type MangaRecommendationResponse = RecommendationData[];

--- a/src/types/schedules.ts
+++ b/src/types/schedules.ts
@@ -1,0 +1,165 @@
+/**
+ * @fileoverview Type definitions for schedule-related API responses
+ */
+
+/**
+ * Scheduled anime entry
+ * @interface ScheduleEntry
+ */
+export interface ScheduleEntry {
+    /** MyAnimeList ID */
+    mal_id: number;
+    /** URL to the anime */
+    url: string;
+    /** Anime title */
+    title: string;
+    /** Anime titles in different languages */
+    titles: Array<{
+        type: string;
+        title: string;
+    }>;
+    /** Anime images */
+    images: {
+        jpg: {
+            image_url: string;
+            small_image_url: string;
+            large_image_url: string;
+        };
+        webp: {
+            image_url: string;
+            small_image_url: string;
+            large_image_url: string;
+        };
+    };
+    /** Anime type */
+    type: string;
+    /** Anime source material */
+    source: string;
+    /** Number of episodes */
+    episodes?: number;
+    /** Airing status */
+    status: string;
+    /** Whether currently airing */
+    airing: boolean;
+    /** Airing period */
+    aired: {
+        from?: string;
+        to?: string;
+        prop: {
+            from: {
+                day?: number;
+                month?: number;
+                year?: number;
+            };
+            to: {
+                day?: number;
+                month?: number;
+                year?: number;
+            };
+        };
+        string: string;
+    };
+    /** Duration per episode */
+    duration: string;
+    /** Age rating */
+    rating: string;
+    /** Anime score */
+    score?: number;
+    /** Number of users who scored */
+    scored_by?: number;
+    /** Anime rank */
+    rank?: number;
+    /** Popularity rank */
+    popularity: number;
+    /** Number of members */
+    members: number;
+    /** Number of favorites */
+    favorites: number;
+    /** Synopsis */
+    synopsis?: string;
+    /** Background information */
+    background?: string;
+    /** Season */
+    season?: string;
+    /** Year */
+    year?: number;
+    /** Broadcast information */
+    broadcast: {
+        day?: string;
+        time?: string;
+        timezone?: string;
+        string?: string;
+    };
+    /** Producers */
+    producers: Array<{
+        mal_id: number;
+        type: string;
+        name: string;
+        url: string;
+    }>;
+    /** Licensors */
+    licensors: Array<{
+        mal_id: number;
+        type: string;
+        name: string;
+        url: string;
+    }>;
+    /** Studios */
+    studios: Array<{
+        mal_id: number;
+        type: string;
+        name: string;
+        url: string;
+    }>;
+    /** Genres */
+    genres: Array<{
+        mal_id: number;
+        type: string;
+        name: string;
+        url: string;
+    }>;
+    /** Explicit genres */
+    explicit_genres: Array<{
+        mal_id: number;
+        type: string;
+        name: string;
+        url: string;
+    }>;
+    /** Themes */
+    themes: Array<{
+        mal_id: number;
+        type: string;
+        name: string;
+        url: string;
+    }>;
+    /** Demographics */
+    demographics: Array<{
+        mal_id: number;
+        type: string;
+        name: string;
+        url: string;
+    }>;
+}
+
+/**
+ * Schedule filter parameters
+ * @interface ScheduleParams
+ */
+export interface ScheduleParams {
+    /** Filter by specific day */
+    filter?: 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' | 'saturday' | 'sunday' | 'other' | 'unknown';
+    /** Safe for work filter */
+    sfw?: boolean;
+    /** Filter unapproved entries */
+    unapproved?: boolean;
+    /** Page number */
+    page?: number;
+    /** Results per page */
+    limit?: number;
+}
+
+/**
+ * Response type for schedules
+ * @type ScheduleResponse
+ */
+export type ScheduleResponse = ScheduleEntry[];

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -1,0 +1,426 @@
+/**
+ * @fileoverview TypeScript type definitions for user-related API responses
+ */
+
+export interface UserResponse {
+    mal_id: number;
+    username: string;
+    url: string;
+    images: {
+        jpg: {
+            image_url: string;
+        };
+        webp: {
+            image_url: string;
+        };
+    };
+    last_online: string;
+    gender?: string;
+    birthday?: string;
+    location?: string;
+    joined: string;
+}
+
+export interface UserStatisticsResponse {
+    anime: {
+        days_watched: number;
+        mean_score: number;
+        watching: number;
+        completed: number;
+        on_hold: number;
+        dropped: number;
+        plan_to_watch: number;
+        total_entries: number;
+        rewatched: number;
+        episodes_watched: number;
+    };
+    manga: {
+        days_read: number;
+        mean_score: number;
+        reading: number;
+        completed: number;
+        on_hold: number;
+        dropped: number;
+        plan_to_read: number;
+        total_entries: number;
+        reread: number;
+        chapters_read: number;
+        volumes_read: number;
+    };
+}
+
+export interface UserFavoritesResponse {
+    anime: Array<{
+        mal_id: number;
+        url: string;
+        images: {
+            jpg: {
+                image_url: string;
+                small_image_url: string;
+                large_image_url: string;
+            };
+            webp: {
+                image_url: string;
+                small_image_url: string;
+                large_image_url: string;
+            };
+        };
+        title: string;
+        type: string;
+        start_year: number;
+    }>;
+    manga: Array<{
+        mal_id: number;
+        url: string;
+        images: {
+            jpg: {
+                image_url: string;
+                small_image_url: string;
+                large_image_url: string;
+            };
+            webp: {
+                image_url: string;
+                small_image_url: string;
+                large_image_url: string;
+            };
+        };
+        title: string;
+        type: string;
+        start_year: number;
+    }>;
+    characters: Array<{
+        mal_id: number;
+        url: string;
+        images: {
+            jpg: {
+                image_url: string;
+            };
+            webp: {
+                image_url: string;
+            };
+        };
+        name: string;
+    }>;
+    people: Array<{
+        mal_id: number;
+        url: string;
+        images: {
+            jpg: {
+                image_url: string;
+            };
+        };
+        name: string;
+    }>;
+}
+
+export interface UserAnimeListResponse {
+    mal_id: number;
+    title: string;
+    url: string;
+    images: {
+        jpg: {
+            image_url: string;
+            small_image_url: string;
+            large_image_url: string;
+        };
+        webp: {
+            image_url: string;
+            small_image_url: string;
+            large_image_url: string;
+        };
+    };
+    type: string;
+    source: string;
+    episodes: number;
+    status: string;
+    airing: boolean;
+    aired: {
+        from: string;
+        to: string;
+        prop: {
+            from: {
+                day: number;
+                month: number;
+                year: number;
+            };
+            to: {
+                day: number;
+                month: number;
+                year: number;
+            };
+        };
+        string: string;
+    };
+    duration: string;
+    rating: string;
+    score: number;
+    scored_by: number;
+    rank: number;
+    popularity: number;
+    members: number;
+    favorites: number;
+    synopsis: string;
+    background: string;
+    season: string;
+    year: number;
+    broadcast: {
+        day: string;
+        time: string;
+        timezone: string;
+        string: string;
+    };
+    producers: Array<{
+        mal_id: number;
+        type: string;
+        name: string;
+        url: string;
+    }>;
+    licensors: Array<{
+        mal_id: number;
+        type: string;
+        name: string;
+        url: string;
+    }>;
+    studios: Array<{
+        mal_id: number;
+        type: string;
+        name: string;
+        url: string;
+    }>;
+    genres: Array<{
+        mal_id: number;
+        type: string;
+        name: string;
+        url: string;
+    }>;
+    explicit_genres: Array<{
+        mal_id: number;
+        type: string;
+        name: string;
+        url: string;
+    }>;
+    themes: Array<{
+        mal_id: number;
+        type: string;
+        name: string;
+        url: string;
+    }>;
+    demographics: Array<{
+        mal_id: number;
+        type: string;
+        name: string;
+        url: string;
+    }>;
+    list_status: {
+        status: string;
+        score: number;
+        tags: string;
+        is_rewatching: boolean;
+        num_watched_episodes: number;
+        start_date: string;
+        finish_date: string;
+    };
+}
+
+export interface UserMangaListResponse {
+    mal_id: number;
+    title: string;
+    url: string;
+    images: {
+        jpg: {
+            image_url: string;
+            small_image_url: string;
+            large_image_url: string;
+        };
+        webp: {
+            image_url: string;
+            small_image_url: string;
+            large_image_url: string;
+        };
+    };
+    type: string;
+    chapters: number;
+    volumes: number;
+    status: string;
+    publishing: boolean;
+    published: {
+        from: string;
+        to: string;
+        prop: {
+            from: {
+                day: number;
+                month: number;
+                year: number;
+            };
+            to: {
+                day: number;
+                month: number;
+                year: number;
+            };
+        };
+        string: string;
+    };
+    score: number;
+    scored_by: number;
+    rank: number;
+    popularity: number;
+    members: number;
+    favorites: number;
+    synopsis: string;
+    background: string;
+    authors: Array<{
+        mal_id: number;
+        type: string;
+        name: string;
+        url: string;
+    }>;
+    serializations: Array<{
+        mal_id: number;
+        type: string;
+        name: string;
+        url: string;
+    }>;
+    genres: Array<{
+        mal_id: number;
+        type: string;
+        name: string;
+        url: string;
+    }>;
+    explicit_genres: Array<{
+        mal_id: number;
+        type: string;
+        name: string;
+        url: string;
+    }>;
+    themes: Array<{
+        mal_id: number;
+        type: string;
+        name: string;
+        url: string;
+    }>;
+    demographics: Array<{
+        mal_id: number;
+        type: string;
+        name: string;
+        url: string;
+    }>;
+    list_status: {
+        status: string;
+        score: number;
+        tags: string;
+        is_rereading: boolean;
+        num_read_chapters: number;
+        num_read_volumes: number;
+        start_date: string;
+        finish_date: string;
+    };
+}
+
+export interface UserFriendsResponse {
+    mal_id: number;
+    username: string;
+    url: string;
+    images: {
+        jpg: {
+            image_url: string;
+        };
+        webp: {
+            image_url: string;
+        };
+    };
+    last_online: string;
+    friends_since: string;
+}
+
+export interface UserReviewResponse {
+    mal_id: number;
+    url: string;
+    type: string;
+    votes: number;
+    date: string;
+    review: string;
+    episodes_watched: number;
+    scores: {
+        overall: number;
+        story: number;
+        animation: number;
+        sound: number;
+        character: number;
+        enjoyment: number;
+    };
+    entry: {
+        mal_id: number;
+        url: string;
+        images: {
+            jpg: {
+                image_url: string;
+                small_image_url: string;
+                large_image_url: string;
+            };
+            webp: {
+                image_url: string;
+                small_image_url: string;
+                large_image_url: string;
+            };
+        };
+        title: string;
+    };
+}
+
+export interface UserRecommendationResponse {
+    mal_id: string;
+    entry: Array<{
+        mal_id: number;
+        url: string;
+        images: {
+            jpg: {
+                image_url: string;
+                small_image_url: string;
+                large_image_url: string;
+            };
+            webp: {
+                image_url: string;
+                small_image_url: string;
+                large_image_url: string;
+            };
+        };
+        title: string;
+    }>;
+    content: string;
+    date: string;
+    user: {
+        url: string;
+        username: string;
+    };
+}
+
+export interface UserClubResponse {
+    mal_id: number;
+    name: string;
+    url: string;
+}
+
+export interface UserUpdateResponse {
+    entry: {
+        mal_id: number;
+        url: string;
+        images: {
+            jpg: {
+                image_url: string;
+                small_image_url: string;
+                large_image_url: string;
+            };
+            webp: {
+                image_url: string;
+                small_image_url: string;
+                large_image_url: string;
+            };
+        };
+        title: string;
+    };
+    score: number;
+    status: string;
+    episodes_seen: number;
+    episodes_total: number;
+    date: string;
+}


### PR DESCRIPTION
- Add People module with 8 endpoints (person details, work, voice acting, search)
- Add Genres module with 2 endpoints (anime/manga genre lists)
- Add Schedules module with 8 endpoints (weekly anime schedules + day-specific methods)
- Add Random module with 5 endpoints (random anime/manga/character/person/user)
- Add Recommendations module with 2 endpoints (recent anime/manga recommendations)
- Add Users module with 13 endpoints (comprehensive user profile functionality)
- Add Characters search endpoint to complete character functionality
- Update main Jikan client to integrate all new modules
- Add comprehensive test suites for all modules (122 tests passing)
- Add detailed documentation for all endpoints in README
- Maintain 100% TypeScript coverage with proper type definitions

Coverage increased from ~45% to 63% (63/100 endpoints implemented) All core discovery and user functionality now available